### PR TITLE
[CMake] Add blend2d-defines header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,10 @@ if (NOT BLEND2D_EMBED)
                           LIBRARY DESTINATION "lib${LIB_SUFFIX}"
                           ARCHIVE DESTINATION "lib${LIB_SUFFIX}")
 
+  # Configure and install 'blend2d' defines header file 
+  configure_file("${BLEND2D_DIR}/src/blend2d-defines.in.h" "${CMAKE_BINARY_DIR}/blend2d-defines.h" @ONLY)
+  install(FILES "${CMAKE_BINARY_DIR}/blend2d-defines.h"  DESTINATION "include/${_src_dir}")
+
   # Install 'blend2d' header files (private headers are filtered out).
   foreach(_src_file ${BLEND2D_SRC_LIST})
     if ("${_src_file}" MATCHES "\\.h$" AND NOT "${_src_file}" MATCHES "_p\\.h$")

--- a/src/blend2d-defines.in.h
+++ b/src/blend2d-defines.in.h
@@ -1,0 +1,10 @@
+#ifndef BLEND2D_DEFINES_H
+#define BLEND2D_DEFINES_H
+
+#cmakedefine BLEND2D_STATIC
+
+#ifdef BLEND2D_STATIC
+#define BL_STATIC
+#endif // BLEND2D_STATIC
+
+#endif // BLEND2D_DEFINES_H


### PR DESCRIPTION
This will allow to include defines generated for specific CMake configuration. While now it is just `BL_STATIC` that may change in the future. Since this file is standalone it will not affect any non-CMake based build systems.