### PR TITLE
[CMake] Fix ClangCL warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "x${CMAKE_CXX_SIMULATE_ID}" ST
     -Oi)                     # [+] Generate Intrinsic Functions.
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    list(APPEND BLEND2D_PRIVATE_CFLAGS -fno-exceptions -fno-rtti -fno-math-errno)
+    list(APPEND BLEND2D_PRIVATE_CFLAGS -clang:-fno-math-errno)
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(GNU|Clang|AppleClang)$")
   list(APPEND BLEND2D_PRIVATE_CFLAGS -Wall -Wextra)


### PR DESCRIPTION
 - If `CMAKE_CXX_SIMULATE_ID` is `MSVC` and `CMAKE_CXX_COMPILER_ID` is `Clang` then Clang emulates VC++ which results in
```
2>clang-cl: warning: unknown argument ignored in clang-cl: '-fno-exceptions' [-Wunknown-argument]
2>clang-cl: warning: unknown argument ignored in clang-cl: '-fno-rtti' [-Wunknown-argument]
2>clang-cl: warning: unknown argument ignored in clang-cl: '-fno-math-errno' [-Wunknown-argument]
```
- `-clang:-fno-exceptions` results in `2>clang-cl: warning: argument unused during compilation: '-fno-exceptions' [-Wunused-command-line-argument]`. `-fno-rtti` is not needed because `-GR-` is passed.

- for MSVC `/EHsc` is set by default so we need to remove it so stack unwinding code would not be generated.