### PR TITLE
[bug] fix undeclared `matchfinder_rebase_sse2` in AVX2

### DIFF
--- a/src/blend2d/compression/matchfinder_p.h
+++ b/src/blend2d/compression/matchfinder_p.h
@@ -231,9 +231,7 @@ static BL_INLINE void matchfinder_rebase(mf_pos_t *data, size_t num_entries) noe
 #if defined(BL_TARGET_OPT_AVX2)
   if (matchfinder_rebase_avx2(data, num_entries * sizeof(data[0])))
     return;
-#endif
-
-#if defined(BL_TARGET_OPT_SSE2)
+#elif defined(BL_TARGET_OPT_SSE2)
   if (matchfinder_rebase_sse2(data, num_entries * sizeof(data[0])))
     return;
 #endif


### PR DESCRIPTION
Fix compilation error of AVX2 target.
`matchfinder_rebase_sse2`  would be undeclared if `BL_TARGET_OPT_AVX2` was defined, which leads to a compilation error.

```
In file included from external/blend2d/src/blend2d/compression/deflateencoder.cpp:36:
external/blend2d/src/blend2d/compression/matchfinder_p.h:237:7: error: use of undeclared identifier 'matchfinder_rebase_sse2'; did you mean 'matchfinder_rebase_avx2'?
  if (matchfinder_rebase_sse2(data, num_entries * sizeof(data[0])))
      ^~~~~~~~~~~~~~~~~~~~~~~
      matchfinder_rebase_avx2
external/blend2d/src/blend2d/compression/matchfinder_p.h:52:25: note: 'matchfinder_rebase_avx2' declared here
  static BL_INLINE bool matchfinder_rebase_avx2(mf_pos_t *data, size_t size) noexcept {
                        ^
1 error generated.
```