### PR TITLE
[MSVC] fix compilation for ARM64 and properly detect ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,22 +167,23 @@ endfunction()
 
 if ("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC" OR "x${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "xMSVC")
   list(APPEND BLEND2D_PRIVATE_CFLAGS
-    -MP                      # [+] Multi-Process Compilation.
-    -GR-                     # [-] Runtime type information.
-    -GF                      # [+] Eliminate duplicate strings.
-    -Zc:__cplusplus          # [+] Conforming __cplusplus definition.
-    -Zc:inline               # [+] Remove unreferenced COMDAT.
-    -Zc:strictStrings        # [+] Strict const qualification of string literals.
-    -Zc:threadSafeInit-      # [-] Thread-safe statics.
-    -W4)                     # [+] Warning level 4.
+    -MP                           # [+] Multi-Process Compilation.
+    -GR-                          # [-] Runtime type information.
+    -GF                           # [+] Eliminate duplicate strings.
+    -Zc:__cplusplus               # [+] Conforming __cplusplus definition.
+    -Zc:inline                    # [+] Remove unreferenced COMDAT.
+    -Zc:strictStrings             # [+] Strict const qualification of string literals.
+    -Zc:threadSafeInit-           # [-] Thread-safe statics.
+    -Zc:arm64-aliased-neon-types- # [-] ARM64 aliased neon types
+    -W4)                          # [+] Warning level 4.
 
   list(APPEND BLEND2D_PRIVATE_CFLAGS_DBG
-    -GS)                     # [+] Buffer security-check.
+    -GS)                          # [+] Buffer security-check.
 
   list(APPEND BLEND2D_PRIVATE_CFLAGS_REL
-    -GS-                     # [-] Buffer security-check.
-    -O2                      # [+] Favor speed over size.
-    -Oi)                     # [+] Generate Intrinsic Functions.
+    -GS-                          # [-] Buffer security-check.
+    -O2                           # [+] Favor speed over size.
+    -Oi)                          # [+] Generate Intrinsic Functions.
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     list(APPEND BLEND2D_PRIVATE_CFLAGS -clang:-fno-rtti -clang:-fno-math-errno -clang:-fno-trapping-math)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,8 +174,10 @@ if ("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC" OR "x${CMAKE_CXX_COMPILER_FRONT
     -Zc:inline                    # [+] Remove unreferenced COMDAT.
     -Zc:strictStrings             # [+] Strict const qualification of string literals.
     -Zc:threadSafeInit-           # [-] Thread-safe statics.
-    -Zc:arm64-aliased-neon-types- # [-] ARM64 aliased neon types
     -W4)                          # [+] Warning level 4.
+
+    # [-] ARM64 aliased neon types
+    blend2d_detect_cflags(BLEND2D_PRIVATE_CFLAGS -Zc:arm64-aliased-neon-types-)
 
   list(APPEND BLEND2D_PRIVATE_CFLAGS_DBG
     -GS)                          # [+] Buffer security-check.

--- a/src/blend2d/api-build_p.h
+++ b/src/blend2d/api-build_p.h
@@ -151,7 +151,7 @@
   #define BL_TARGET_ARCH_X86 0
 #endif
 
-#if defined(__ARM64__) || defined(__aarch64__)
+#if defined(_M_ARM64) || defined(__ARM64__) || defined(__aarch64__)
   #define BL_TARGET_ARCH_ARM 64
 #elif defined(_M_ARM) || defined(_M_ARMT) || defined(__arm__) || defined(__thumb__) || defined(__thumb2__)
   #define BL_TARGET_ARCH_ARM 32

--- a/src/blend2d/compression/matchfinder_p.h
+++ b/src/blend2d/compression/matchfinder_p.h
@@ -125,7 +125,7 @@ typedef int16_t mf_pos_t;
       return false;
 
     size_t n = size / 64u;
-    int16x8_t v = (int16x8_t) {
+    int16x8_t v = int16x8_t {
       MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
       MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
       MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
@@ -150,7 +150,7 @@ typedef int16_t mf_pos_t;
       return false;
 
     size_t n = size / 64u;
-    int16x8_t v = (int16x8_t) {
+    int16x8_t v = int16x8_t {
       MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
       MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
       MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,

--- a/src/blend2d/compression/matchfinder_p.h
+++ b/src/blend2d/compression/matchfinder_p.h
@@ -125,11 +125,7 @@ typedef int16_t mf_pos_t;
       return false;
 
     size_t n = size / 64u;
-    int16x8_t v = int16x8_t {
-      MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
-      MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
-      MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
-    };
+    int16x8_t v = vdupq_n_s16(int16_t(MATCHFINDER_WINDOW_SIZE_NEG));
     int16x8_t* p = (int16x8_t *)data;
 
     do {
@@ -150,12 +146,7 @@ typedef int16_t mf_pos_t;
       return false;
 
     size_t n = size / 64u;
-    int16x8_t v = int16x8_t {
-      MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
-      MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
-      MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
-      MATCHFINDER_WINDOW_SIZE_NEG, MATCHFINDER_WINDOW_SIZE_NEG,
-    };
+    int16x8_t v = vdupq_n_s16(int16_t(MATCHFINDER_WINDOW_SIZE_NEG));
     int16x8_t* p = (int16x8_t *)data;
 
     do {

--- a/src/blend2d/pipeline/pipedefs_p.h
+++ b/src/blend2d/pipeline/pipedefs_p.h
@@ -16,6 +16,7 @@
 #include "../runtime_p.h"
 #include "../tables_p.h"
 #include "../simd_p.h"
+#include "../support/memops_p.h"
 
 //! \cond INTERNAL
 //! \addtogroup blend2d_internal


### PR DESCRIPTION
Including `#include "../support/memops_p.h"` fixes the compilation for good, provided used asmjit contains mvn workaround.
On the other hand, properly detecting ARM64 under MSVC introduces a new problem:
[asmjit_arm64_build_output.log](https://github.com/blend2d/blend2d/files/11347497/asmjit_arm64_build_output.log)
