### PR TITLE
Correcting insecure string for Clang 16

### DIFF
--- a/test/bl_test_utilities.h
+++ b/test/bl_test_utilities.h
@@ -11,6 +11,7 @@
 #include <blend2d.h>
 #include <stdlib.h>
 #include <string.h>
+#include <iostream>
 
 class CmdLine {
 public:
@@ -83,7 +84,7 @@ public:
 
   template<typename... Args>
   inline void print(Args&&... args) {
-    printf(std::forward<Args>(args)...);
+    (std::cout << ... << args) << std::endl;
     fflush(stdout);
   }
 


### PR DESCRIPTION
Without this modification i get the following error on Clang 16.0.6 :

../test/bl_test_utilities.h:86:12: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
    printf(std::forward<Args>(args)...);
