### PR TITLE
[bug] Use find_dependency(asmjit)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1066,13 +1066,20 @@ if (NOT BLEND2D_EMBED)
   # Add Blend2D install instructions (library and public headers).
   if (NOT BLEND2D_NO_INSTALL)
     install(TARGETS blend2d
-            EXPORT blend2d-config
+            EXPORT blend2d-targets
             RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-    install(EXPORT blend2d-config
+    install(EXPORT blend2d-targets
             NAMESPACE blend2d::
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/blend2d")
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file("${CMAKE_CURRENT_LIST_DIR}/blend2d-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/blend2d-config.cmake"
+            INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/blend2d"
+            NO_SET_AND_CHECK_MACRO
+            NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/blend2d-config.cmake"
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/blend2d")
 
     foreach(_src_file ${BLEND2D_SRC_LIST})

--- a/blend2d-config.cmake.in
+++ b/blend2d-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+if("@BLEND2D_EXTERNAL_ASMJIT@" AND "@BLEND2D_STATIC@")
+    include(CMakeFindDependencyMacro)
+    find_dependency(asmjit)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/blend2d-targets.cmake")


### PR DESCRIPTION
When using an external asmjit with static library linkage, there is a link-only dependency on `asmjit::asmjit` which must be resolved by blend2d cmake config with `find_dependency`.

For https://github.com/microsoft/vcpkg/pull/39730.

The CMake config could be more minimal, but using `configure_package_config_file` opens the door for other package interface options (version, components, variables, file checks).