### PR TITLE
Compile time guard around crc32_update_sse4_2

### DIFF
--- a/blend2d/compression/checksum.cpp
+++ b/blend2d/compression/checksum.cpp
@@ -158,9 +158,12 @@ void bl_compression_rt_init(BLRuntimeContext* rt) noexcept {
     ft.adler32 = bl::Compression::Checksum::adler32_update_sse2;
   }
 
+#if defined(BL_BUILD_OPT_SSE4_2)
   if (bl_runtime_has_sse4_2(rt)) {
     ft.crc32 = bl::Compression::Checksum::crc32_update_sse4_2;
   }
+#endif // BL_BUILD_OPT_SSE4_2
+
 #endif // BL_TARGET_ARCH_X86
 
 #if defined(BL_BUILD_OPT_ASIMD)


### PR DESCRIPTION
I believe a compile time guard is required around crc32_update_sse4_2 in checksum.cpp. 

The definition of crc32_update_sse4_2 is inside a compiler guard, so the guard is needed for a sse2 level build. 