### PR TITLE
Add support for rational bezier curves and port path stroker from Skia.

### DIFF
--- a/blend2d-testing/demos/bl_demo_stroke.cpp
+++ b/blend2d-testing/demos/bl_demo_stroke.cpp
@@ -191,19 +191,31 @@ public:
 
     auto rx = [&]() { return _prng.next_double() * (max_x - min_x) + min_x; };
     auto ry = [&]() { return _prng.next_double() * (max_y - min_y) + min_y; };
+    auto rw = [&]() {
+      double w = _prng.next_double();
+      if (w > 0.5) {
+        return 0.5 / (w - 0.5);
+      } else {
+        return (0.5 - w) / 0.5;
+      }
+    };
 
     _path.clear();
     _path.move_to(rx(), ry());
 
     double cmd = _prng.next_double();
-    if (cmd < 0.33) {
+    if (cmd < 0.25) {
       _path.line_to(rx(), ry());
       _path.line_to(rx(), ry());
       _path.line_to(rx(), ry());
     }
-    else if (cmd < 0.66) {
+    else if (cmd < 0.5) {
       _path.quad_to(rx(), ry(), rx(), ry());
       _path.quad_to(rx(), ry(), rx(), ry());
+    }
+    else if (cmd < 0.75) {
+      _path.conic_to(rx(), ry(), rx(), ry(), rw());
+      _path.conic_to(rx(), ry(), rx(), ry(), rw());
     }
     else {
       _path.cubic_to(rx(), ry(), rx(), ry(), rx(), ry());
@@ -286,9 +298,11 @@ public:
   Q_SLOT void onDumpPath() {
     size_t count = _path.size();
     const BLPoint* vtx = _path.vertex_data();
+    const double *conic_weight = _path.conic_weight_data();
     const uint8_t* cmd = _path.command_data();
 
     size_t i = 0;
+    size_t j = 0;
     while (i < count) {
       switch (cmd[i]) {
         case BL_PATH_CMD_MOVE:
@@ -302,6 +316,11 @@ public:
         case BL_PATH_CMD_QUAD:
           printf("p.quadTo(%g, %g, %g, %g);\n", vtx[i].x, vtx[i].y, vtx[i+1].x, vtx[i+1].y);
           i += 2;
+          break;
+        case BL_PATH_CMD_CONIC:
+          printf("p.conicTo(%g, %g, %g, %g, %g);\n", vtx[i].x, vtx[i].y, vtx[i+1].x, vtx[i+1].y, conic_weight[j]);
+          i += 2;
+          j++;
           break;
         case BL_PATH_CMD_CUBIC:
           printf("p.cubicTo(%g, %g, %g, %g, %g, %g);\n", vtx[i].x, vtx[i].y, vtx[i+1].x, vtx[i+1].y, vtx[i+2].x, vtx[i+2].y);

--- a/blend2d/blend2d-debug.h
+++ b/blend2d/blend2d-debug.h
@@ -497,10 +497,12 @@ static void bl_debug_gradient_(const BLGradientCore* obj, const char* name, int 
 
 static void bl_debug_path_(const BLPathCore* obj, const char* name, int indent) {
   size_t i = 0;
+  size_t j = 0;
   size_t size = bl_path_get_size(obj);
 
   const uint8_t* cmd = bl_path_get_command_data(obj);
   const BLPoint* vtx = bl_path_get_vertex_data(obj);
+  const double* conic_weight_data = bl_path_get_conic_weight_data(obj);
 
   BL_DEBUG_FMT("%s: {\n", name);
   indent++;
@@ -520,6 +522,13 @@ static void bl_debug_path_(const BLPathCore* obj, const char* name, int indent) 
           break;
         BL_DEBUG_FMT("p.quad_to(%g, %g, %g, %g);\n", vtx[i].x, vtx[i].y, vtx[i+1].x, vtx[i+1].y);
         i += 2;
+        continue;
+      case BL_PATH_CMD_CONIC:
+        if ((size - i) < 2)
+          break;
+        BL_DEBUG_FMT("p.conic_to(%g, %g, %g, %g, %g);\n", vtx[i].x, vtx[i].y, vtx[i+1].x, vtx[i+1].y, conic_weight_data[j]);
+        i += 2;
+        j++;
         continue;
       case BL_PATH_CMD_CUBIC:
         if ((size - i) < 3)

--- a/blend2d/core/path.cpp
+++ b/blend2d/core/path.cpp
@@ -54,6 +54,17 @@ static BL_INLINE void copy_content(uint8_t* cmd_dst, BLPoint* vtx_dst, const uin
   }
 }
 
+static BL_INLINE void copy_weights(double* dst, const double* src, size_t n) noexcept {
+  for (size_t i = 0; i < n; i++)
+    dst[i] = src[i];
+}
+
+static BL_INLINE BLPathView make_view(const BLPathPrivateImpl* impl, size_t start, size_t n) noexcept {
+  size_t conic_start = count_conics(impl->command_data, start);
+  size_t conic_weight_size = count_conics(impl->command_data + start, n);
+  return BLPathView { impl->command_data + start, impl->vertex_data + start, impl->conic_weight_data + conic_start, n, conic_weight_size };
+}
+
 // bl::Path - Internals
 // ====================
 
@@ -79,7 +90,7 @@ static BL_INLINE void set_size(BLPathCore* self, size_t size) noexcept {
   get_impl(self)->size = size;
 }
 
-static BL_INLINE BLResult alloc_impl(BLPathCore* self, size_t size, BLObjectImplSize impl_size) noexcept {
+static BL_INLINE BLResult alloc_impl(BLPathCore* self, size_t size, size_t conic_weight_size, BLObjectImplSize impl_size) noexcept {
   size_t capacity = capacity_from_impl_size(impl_size);
 
   BLObjectInfo info = BLObjectInfo::from_type_with_marker(BL_OBJECT_TYPE_PATH);
@@ -87,11 +98,14 @@ static BL_INLINE BLResult alloc_impl(BLPathCore* self, size_t size, BLObjectImpl
 
   BLPathPrivateImpl* impl = get_impl(self);
   BLPoint* vertex_data = PtrOps::offset<BLPoint>(impl, sizeof(BLPathPrivateImpl));
-  uint8_t* command_data = PtrOps::offset<uint8_t>(vertex_data, capacity * sizeof(BLPoint));
+  double* conic_weight_data = PtrOps::offset<double>(vertex_data, capacity * sizeof(BLPoint));
+  uint8_t* command_data = PtrOps::offset<uint8_t>(conic_weight_data, capacity * sizeof(double));
 
   impl->command_data = command_data;
   impl->vertex_data = vertex_data;
+  impl->conic_weight_data = conic_weight_data;
   impl->size = size;
+  impl->conic_weight_size = conic_weight_size;
   impl->capacity = capacity;
   impl->flags = BL_PATH_FLAG_DIRTY;
   return BL_SUCCESS;
@@ -102,32 +116,37 @@ static BL_INLINE BLResult alloc_impl(BLPathCore* self, size_t size, BLObjectImpl
 static BL_NOINLINE BLResult realloc_path(BLPathCore* self, BLObjectImplSize impl_size) noexcept {
   BLPathPrivateImpl* old_impl = get_impl(self);
   size_t path_size = old_impl->size;
+  size_t conic_weight_size = old_impl->conic_weight_size;
 
   BLPathCore newO;
-  BL_PROPAGATE(alloc_impl(&newO, path_size, impl_size));
+  BL_PROPAGATE(alloc_impl(&newO, path_size, conic_weight_size, impl_size));
 
   BLPathPrivateImpl* new_impl = get_impl(&newO);
   copy_content(new_impl->command_data, new_impl->vertex_data, old_impl->command_data, old_impl->vertex_data, path_size);
+  copy_weights(new_impl->conic_weight_data, old_impl->conic_weight_data, conic_weight_size);
   return replace_instance(self, &newO);
 }
 
 // Called by `prepare_add` and some others to create a new path, copy a content from `self` into it, and release
 // the current impl. The size of the new path will be set to `new_size` so this function should really be only used
 // as an append fallback.
-static BL_NOINLINE BLResult realloc_path_to_add(BLPathCore* self, size_t new_size, uint8_t** cmd_out, BLPoint** vtx_out) noexcept {
+static BL_NOINLINE BLResult realloc_path_to_add(BLPathCore* self, size_t new_size, size_t new_conic_weight_size, uint8_t** cmd_out, BLPoint** vtx_out, double** conic_weight_out) noexcept {
   BLObjectImplSize impl_size = expand_impl_size(impl_size_from_capacity(new_size));
 
   BLPathCore newO;
-  BL_PROPAGATE(alloc_impl(&newO, new_size, impl_size));
+  BL_PROPAGATE(alloc_impl(&newO, new_size, new_conic_weight_size, impl_size));
 
   BLPathPrivateImpl* old_impl = get_impl(self);
   BLPathPrivateImpl* new_impl = get_impl(&newO);
 
   size_t old_size = old_impl->size;
+  size_t old_conic_weight_size = old_impl->conic_weight_size;
   copy_content(new_impl->command_data, new_impl->vertex_data, old_impl->command_data, old_impl->vertex_data, old_size);
+  copy_weights(new_impl->conic_weight_data, old_impl->conic_weight_data, old_conic_weight_size);
 
   *cmd_out = new_impl->command_data + old_size;
   *vtx_out = new_impl->vertex_data + old_size;
+  *conic_weight_out = new_impl->conic_weight_data + old_conic_weight_size;
   return replace_instance(self, &newO);
 }
 
@@ -144,25 +163,34 @@ static BL_NOINLINE BLResult realloc_path_to_add(BLPathCore* self, size_t new_siz
 //
 // which would be always smaller than SIZE_MAX / 2 so we can assume that apending two paths would never overflow
 // the maximum theoretical Path capacity represented by `size_t` type.
-static BL_INLINE BLResult prepare_add(BLPathCore* self, size_t n, uint8_t** cmd_out, BLPoint** vtx_out) noexcept {
+static BL_INLINE BLResult prepare_add(BLPathCore* self, size_t n, size_t conic_weight_n, uint8_t** cmd_out, BLPoint** vtx_out, double** conic_weight_out) noexcept {
   BLPathPrivateImpl* self_impl = get_impl(self);
 
   size_t size = self_impl->size;
   size_t size_after = size + n;
-  size_t immutable_msk = IntOps::bool_as_mask<size_t>(!is_impl_mutable(self_impl));
+  size_t conic_weight_size = self_impl->conic_weight_size;
+  size_t conic_weight_size_after = conic_weight_size + conic_weight_n;
+  bool immutable = !is_impl_mutable(self_impl);
 
-  if ((size_after | immutable_msk) > self_impl->capacity)
-    return realloc_path_to_add(self, size_after, cmd_out, vtx_out);
+  if (immutable || size_after > self_impl->capacity || conic_weight_size_after > self_impl->capacity)
+    return realloc_path_to_add(self, size_after, conic_weight_size_after, cmd_out, vtx_out, conic_weight_out);
 
   // Likely case, appending to a path that is not shared and has the required capacity. We have to clear FLAGS
   // in addition to set the new size as flags can contain bits regarding BLPathInfo that will no longer hold.
   self_impl->flags = BL_PATH_FLAG_DIRTY;
   self_impl->size = size_after;
+  self_impl->conic_weight_size = conic_weight_size_after;
 
   *cmd_out = self_impl->command_data + size;
   *vtx_out = self_impl->vertex_data + size;
+  *conic_weight_out = self_impl->conic_weight_data + conic_weight_size;
 
   return BL_SUCCESS;
+}
+
+static BL_INLINE BLResult prepare_add(BLPathCore* self, size_t n, uint8_t** cmd_out, BLPoint** vtx_out) noexcept {
+  double* conic_weight_out;
+  return prepare_add(self, n, 0, cmd_out, vtx_out, &conic_weight_out);
 }
 
 static BL_INLINE BLResult make_mutable(BLPathCore* self) noexcept {
@@ -343,6 +371,22 @@ BL_API_IMPL const BLPoint* bl_path_get_vertex_data(const BLPathCore* self) BL_NO
   return self_impl->vertex_data;
 }
 
+BL_API_IMPL const double* bl_path_get_conic_weight_data(const BLPathCore* self) BL_NOEXCEPT_C {
+  using namespace bl::PathInternal;
+  BL_ASSERT(self->_d.is_path());
+
+  BLPathPrivateImpl* self_impl = get_impl(self);
+  return self_impl->conic_weight_data;
+}
+
+BL_API_IMPL size_t bl_path_get_conic_weight_size(const BLPathCore* self) BL_NOEXCEPT_C {
+  using namespace bl::PathInternal;
+  BL_ASSERT(self->_d.is_path());
+
+  BLPathPrivateImpl* self_impl = get_impl(self);
+  return self_impl->conic_weight_size;
+}
+
 BL_API_IMPL BLResult bl_path_clear(BLPathCore* self) noexcept {
   using namespace bl::PathInternal;
   BL_ASSERT(self->_d.is_path());
@@ -352,6 +396,7 @@ BL_API_IMPL BLResult bl_path_clear(BLPathCore* self) noexcept {
     return replace_instance(self, static_cast<BLPathCore*>(&bl_object_defaults[BL_OBJECT_TYPE_PATH]));
 
   self_impl->size = 0;
+  self_impl->conic_weight_size = 0;
   self_impl->flags = 0;
   return BL_SUCCESS;
 }
@@ -391,35 +436,42 @@ BL_API_IMPL BLResult bl_path_reserve(BLPathCore* self, size_t n) noexcept {
   return BL_SUCCESS;
 }
 
-BL_API_IMPL BLResult bl_path_modify_op(BLPathCore* self, BLModifyOp op, size_t n, uint8_t** cmd_data_out, BLPoint** vtx_data_out) noexcept {
+BL_API_IMPL BLResult bl_path_modify_op_ex(BLPathCore* self, BLModifyOp op, size_t n, size_t conic_weight_n, uint8_t** cmd_data_out, BLPoint** vtx_data_out, double** conic_weight_data_out) noexcept {
   using namespace bl::PathInternal;
   BL_ASSERT(self->_d.is_path());
 
   BLPathPrivateImpl* self_impl = get_impl(self);
   size_t index = bl_modify_op_is_append(op) ? self_impl->size : size_t(0);
-  size_t immutable_msk = bl::IntOps::bool_as_mask<size_t>(!is_impl_mutable(self_impl));
+  size_t conic_index = bl_modify_op_is_append(op) ? self_impl->conic_weight_size : size_t(0);
+  bool immutable = !is_impl_mutable(self_impl);
 
   size_t remaining = self_impl->capacity - index;
+  size_t conic_remaining = self_impl->capacity - conic_index;
   size_t size_after = index + n;
+  size_t conic_size_after = conic_index + conic_weight_n;
 
-  if ((n | immutable_msk) > remaining) {
+  if (immutable || n > remaining || conic_weight_n > conic_remaining) {
     *cmd_data_out = nullptr;
     *vtx_data_out = nullptr;
+    *conic_weight_data_out = nullptr;
 
     BLPathCore newO;
     BLObjectImplSize impl_size = expand_impl_size_with_modify_op(impl_size_from_capacity(size_after), op);
-    BL_PROPAGATE(alloc_impl(&newO, size_after, impl_size));
+    BL_PROPAGATE(alloc_impl(&newO, size_after, conic_size_after, impl_size));
 
     BLPathPrivateImpl* new_impl = get_impl(&newO);
     *cmd_data_out = new_impl->command_data + index;
     *vtx_data_out = new_impl->vertex_data + index;
+    *conic_weight_data_out = new_impl->conic_weight_data + conic_index;
 
     copy_content(new_impl->command_data, new_impl->vertex_data, self_impl->command_data, self_impl->vertex_data, index);
+    copy_weights(new_impl->conic_weight_data, self_impl->conic_weight_data, conic_index);
     return replace_instance(self, &newO);
   }
 
-  if (n) {
+  if (n || conic_weight_n) {
     self_impl->size = size_after;
+    self_impl->conic_weight_size = conic_size_after;
   }
   else if (!index) {
     bl_path_clear(self);
@@ -429,6 +481,7 @@ BL_API_IMPL BLResult bl_path_modify_op(BLPathCore* self, BLModifyOp op, size_t n
   self_impl->flags = BL_PATH_FLAG_DIRTY;
   *vtx_data_out = self_impl->vertex_data + index;
   *cmd_data_out = self_impl->command_data + index;
+  *conic_weight_data_out = self_impl->conic_weight_data + conic_index;
 
   return BL_SUCCESS;
 }
@@ -473,17 +526,20 @@ BL_API_IMPL BLResult bl_path_assign_deep(BLPathCore* self, const BLPathCore* oth
   size_t immutable_msk = bl::IntOps::bool_as_mask<size_t>(!is_impl_mutable(self_impl));
   if ((size | immutable_msk) > self_impl->capacity) {
     BLPathCore newO;
-    BL_PROPAGATE(alloc_impl(&newO, size, impl_size_from_capacity(size)));
+    BL_PROPAGATE(alloc_impl(&newO, size, other_impl->conic_weight_size, impl_size_from_capacity(size)));
 
     BLPathPrivateImpl* new_impl = get_impl(&newO);
     copy_content(new_impl->command_data, new_impl->vertex_data, other_impl->command_data, other_impl->vertex_data, size);
+    copy_weights(new_impl->conic_weight_data, other_impl->conic_weight_data, other_impl->conic_weight_size);
     return replace_instance(self, &newO);
   }
 
   self_impl->flags = BL_PATH_FLAG_DIRTY;
   self_impl->size = size;
+  self_impl->conic_weight_size = other_impl->conic_weight_size;
 
   copy_content(self_impl->command_data, self_impl->vertex_data, other_impl->command_data, other_impl->vertex_data, size);
+  copy_weights(self_impl->conic_weight_data, other_impl->conic_weight_data, other_impl->conic_weight_size);
   return BL_SUCCESS;
 }
 
@@ -586,6 +642,7 @@ public:
     const uint8_t* cmd_data = view.command_data;
     const uint8_t* cmd_end = view.command_data + view.size;
     const BLPoint* vtx_data = view.vertex_data;
+    const double* conic_weight_data = view.conic_weight_data;
 
     // Iterate over the whole path.
     while (cmd_data != cmd_end) {
@@ -636,8 +693,8 @@ public:
         }
 
         case BL_PATH_CMD_CONIC: {
-          cmd_data += 3;
-          vtx_data += 3;
+          cmd_data += 2;
+          vtx_data += 2;
 
           if (cmd_data > cmd_end || !has_prev_vertex)
             return bl_make_error(BL_ERROR_INVALID_GEOMETRY);
@@ -647,15 +704,17 @@ public:
           Geometry::bound(bounding_box, vtx_data[-1]);
 
           // Calculate tight bounding-box only when control points are outside the current one.
-          const BLPoint& ctrl = vtx_data[-3];
+          const BLPoint& ctrl = vtx_data[-2];
 
           if (!(ctrl.x >= bounding_box.x0 && ctrl.y >= bounding_box.y0 && ctrl.x <= bounding_box.x1 && ctrl.y <= bounding_box.y1)) {
+            BLPoint conic[4] { vtx_data[-3], vtx_data[-2], BLPoint(conic_weight_data[0], Math::nan<double>()), vtx_data[-1] };
             BLPoint extrema[2];
-            Geometry::get_conic_extrema_points(vtx_data - 4, extrema);
+            Geometry::get_conic_extrema_points(conic, extrema);
             Geometry::bound(bounding_box, extrema[0]);
             Geometry::bound(bounding_box, extrema[1]);
             Geometry::bound(control_box, vtx_data[-2]);
           }
+          conic_weight_data++;
           break;
         }
 
@@ -800,7 +859,7 @@ static BLResult copy_content_reversed(PathAppender& dst, PathIterator src, BLPat
 
       size_t figure_size = (size_t)(p - src.cmd);
 
-      next.reset(src.cmd + figure_size, src.vtx + figure_size, src.remaining_forward() - figure_size);
+      next.reset(src.cmd + figure_size, src.vtx + figure_size, src.conic_weight_data + count_conics(src.cmd, figure_size), src.remaining_forward() - figure_size);
       src.end = src.cmd + figure_size;
     }
 
@@ -845,7 +904,10 @@ static BLResult copy_content_reversed(PathAppender& dst, PathIterator src, BLPat
         if (cmd == BL_PATH_CMD_CLOSE)
           break;
 
-        dst.add_vertex(src.cmd[0], src.vtx[0]);
+        if (src.cmd[0] == BL_PATH_CMD_CONIC)
+          dst.add_conic_control(src.vtx[0], src.conic_weight_data[0]);
+        else
+          dst.add_vertex(src.cmd[0], src.vtx[0]);
         src--;
       }
 
@@ -872,12 +934,15 @@ static BLResult append_transformed_path_with_type(BLPathCore* self, const BLPath
 
   uint8_t* cmd_data;
   BLPoint* vtx_data;
+  double* conic_weight_data;
+  size_t conic_count = count_conics(other_impl->command_data + start, n);
 
   // Maybe `self` and `other` were the same, so get the `other` impl again.
-  BL_PROPAGATE(prepare_add(self, n, &cmd_data, &vtx_data));
+  BL_PROPAGATE(prepare_add(self, n, conic_count, &cmd_data, &vtx_data, &conic_weight_data));
   other_impl = get_impl(other);
 
   memcpy(cmd_data, other_impl->command_data + start, n);
+  copy_weights(conic_weight_data, other_impl->conic_weight_data + count_conics(other_impl->command_data, start), conic_count);
   return TransformInternal::map_pointd_array_funcs[transform_type](transform, vtx_data, other_impl->vertex_data + start, n);
 }
 
@@ -899,6 +964,9 @@ BL_API_IMPL BLResult bl_path_set_vertex_at(BLPathCore* self, size_t index, uint3
 
   uint32_t old_cmd = self_impl->command_data[index];
   if (cmd == BL_PATH_CMD_PRESERVE) cmd = old_cmd;
+
+  if (BL_UNLIKELY((old_cmd == BL_PATH_CMD_CONIC || cmd == BL_PATH_CMD_CONIC) && cmd != old_cmd))
+    return bl_make_error(BL_ERROR_INVALID_VALUE);
 
   // NOTE: We don't check `cmd` as we don't care of the value. Invalid commands
   // must always be handled by all Blend2D functions anyway so let it fail at
@@ -976,15 +1044,15 @@ BL_API_IMPL BLResult bl_path_conic_to(BLPathCore* self, double x1, double y1, do
 
   uint8_t* cmd_data;
   BLPoint* vtx_data;
-  BL_PROPAGATE(prepare_add(self, 3, &cmd_data, &vtx_data));
+  double* conic_weight_data;
+  BL_PROPAGATE(prepare_add(self, 2, 1, &cmd_data, &vtx_data, &conic_weight_data));
 
   vtx_data[0].reset(x1, y1);
-  vtx_data[1].reset(w, bl::Math::nan<double>());
-  vtx_data[2].reset(x2, y2);
+  vtx_data[1].reset(x2, y2);
+  conic_weight_data[0] = w;
 
   cmd_data[0] = BL_PATH_CMD_CONIC;
-  cmd_data[1] = BL_PATH_CMD_WEIGHT;
-  cmd_data[2] = BL_PATH_CMD_ON;
+  cmd_data[1] = BL_PATH_CMD_ON;
 
   return BL_SUCCESS;
 }
@@ -1090,7 +1158,7 @@ BL_API_IMPL BLResult bl_path_arc_to(BLPathCore* self, double x, double y, double
     }
   }
 
-  BL_PROPAGATE(dst.begin_append(self, 13));
+  BL_PROPAGATE(dst.begin_append(self, 13, 1));
   arc_to_cubic_spline(dst, BLPoint(x, y), BLPoint(rx, ry), start, sweep, initial_cmd, maybe_redundant_line_to);
 
   dst.done(self);
@@ -1109,19 +1177,15 @@ BL_API_IMPL BLResult bl_path_arc_quadrant_to(BLPathCore* self, double x1, double
 
   uint8_t* cmd_data;
   BLPoint* vtx_data;
-  BL_PROPAGATE(prepare_add(self, 3, &cmd_data, &vtx_data));
+  double* conic_weight_data;
+  BL_PROPAGATE(prepare_add(self, 2, 1, &cmd_data, &vtx_data, &conic_weight_data));
 
-  BLPoint p0 = vtx_data[-1];
-  BLPoint p1(x1, y1);
-  BLPoint p2(x2, y2);
+  vtx_data[0].reset(x1, y1);
+  vtx_data[1].reset(x2, y2);
+  conic_weight_data[0] = bl::Math::kSQRT_0p5;
 
-  vtx_data[0].reset(p0 + (p1 - p0) * bl::Math::kKAPPA);
-  vtx_data[1].reset(p2 + (p1 - p2) * bl::Math::kKAPPA);
-  vtx_data[2].reset(p2);
-
-  cmd_data[0] = BL_PATH_CMD_CUBIC;
-  cmd_data[1] = BL_PATH_CMD_CUBIC;
-  cmd_data[2] = BL_PATH_CMD_ON;
+  cmd_data[0] = BL_PATH_CMD_CONIC;
+  cmd_data[1] = BL_PATH_CMD_ON;
 
   return BL_SUCCESS;
 }
@@ -1249,7 +1313,7 @@ BL_API_IMPL BLResult bl_path_elliptic_arc_to(BLPathCore* self, double rx, double
   if (sweep_angle < bl::Math::kPI_DIV_2   + bl::Math::kANGLE_EPSILON) i = 0;
 
   bl::PathAppender appender;
-  BL_PROPAGATE(appender.begin(self, BL_MODIFY_OP_APPEND_GROW, (i + 1) * 3));
+  BL_PROPAGATE(appender.begin(self, BL_MODIFY_OP_APPEND_GROW, (i + 1) * 2, i + 1));
 
   // Process 90 degree segments.
   while (i) {
@@ -1396,9 +1460,13 @@ BL_API_IMPL BLResult bl_path_add_geometry(BLPathCore* self, BLGeometryType geome
   // Should never be zero if we went here.
   BL_ASSERT(n != 0);
   size_t initial_size = get_size(self);
+  size_t initial_conic_weight_size = get_impl(self)->conic_weight_size;
+  size_t conic_n = geometry_type == BL_GEOMETRY_TYPE_PATH && dir != BL_GEOMETRY_DIRECTION_CW
+    ? static_cast<const BLPath*>(geometry_data)->conic_weight_size()
+    : 0;
 
   bl::PathAppender appender;
-  BL_PROPAGATE(appender.begin_append(self, n));
+  BL_PROPAGATE(appender.begin_append(self, n, conic_n));
 
   // For adding 'BLBox', 'BLBoxI', 'BLRect', 'BLRectI', and `BLRoundRect`.
   double x0, y0;
@@ -1767,6 +1835,7 @@ AddBoxD:
 
       if (result != BL_SUCCESS) {
         set_size(self, initial_size);
+        get_impl(self)->conic_weight_size = initial_conic_weight_size;
         return result;
       }
       break;
@@ -1800,12 +1869,15 @@ BL_API_IMPL BLResult bl_path_add_path(BLPathCore* self, const BLPathCore* other,
 
   uint8_t* cmd_data;
   BLPoint* vtx_data;
+  double* conic_weight_data;
+  size_t conic_count = count_conics(other_impl->command_data + start, n);
 
   // Maybe `self` and `other` are the same, so get the `other` impl.
-  BL_PROPAGATE(prepare_add(self, n, &cmd_data, &vtx_data));
+  BL_PROPAGATE(prepare_add(self, n, conic_count, &cmd_data, &vtx_data, &conic_weight_data));
   other_impl = get_impl(other);
 
   copy_content(cmd_data, vtx_data, other_impl->command_data + start, other_impl->vertex_data + start, n);
+  copy_weights(conic_weight_data, other_impl->conic_weight_data + count_conics(other_impl->command_data, start), conic_count);
   return BL_SUCCESS;
 }
 
@@ -1833,15 +1905,18 @@ BL_API_IMPL BLResult bl_path_add_transformed_path(BLPathCore* self, const BLPath
 
   uint8_t* cmd_data;
   BLPoint* vtx_data;
+  double* conic_weight_data;
+  size_t conic_count = count_conics(other_impl->command_data + start, n);
 
   // Maybe `self` and `other` were the same, so get the `other` impl again.
-  BL_PROPAGATE(prepare_add(self, n, &cmd_data, &vtx_data));
+  BL_PROPAGATE(prepare_add(self, n, conic_count, &cmd_data, &vtx_data, &conic_weight_data));
   other_impl = get_impl(other);
 
   // Only check the transform type if we reach the limit as the check costs some cycles.
   BLTransformType transform_type = (n >= BL_MATRIX_TYPE_MINIMUM_SIZE) ? transform->type() : BL_TRANSFORM_TYPE_AFFINE;
 
   memcpy(cmd_data, other_impl->command_data + start, n);
+  copy_weights(conic_weight_data, other_impl->conic_weight_data + count_conics(other_impl->command_data, start), conic_count);
   return bl::TransformInternal::map_pointd_array_funcs[transform_type](transform, vtx_data, other_impl->vertex_data + start, n);
 }
 
@@ -1862,18 +1937,21 @@ BL_API_IMPL BLResult bl_path_add_reversed_path(BLPathCore* self, const BLPathCor
 
   size_t initial_size = get_size(self);
   bl::PathAppender dst;
-  BL_PROPAGATE(dst.begin_append(self, n));
+  size_t initial_conic_weight_size = get_impl(self)->conic_weight_size;
+  BL_PROPAGATE(dst.begin_append(self, n, count_conics(other_impl->command_data + start, n)));
 
   // Maybe `self` and `other` were the same, so get the `other` impl again.
   other_impl = get_impl(other);
-  bl::PathIterator src(other_impl->command_data + start, other_impl->vertex_data + start, n);
+  bl::PathIterator src(other_impl->command_data + start, other_impl->vertex_data + start, other_impl->conic_weight_data + count_conics(other_impl->command_data, start), n);
 
   BLResult result = copy_content_reversed(dst, src, reverse_mode);
   dst.done(self);
 
   // Don't keep anything if reversal failed.
-  if (result != BL_SUCCESS)
+  if (result != BL_SUCCESS) {
     set_size(self, initial_size);
+    get_impl(self)->conic_weight_size = initial_conic_weight_size;
+  }
   return result;
 }
 
@@ -1896,8 +1974,12 @@ static BLResult join_figure(PathAppender& dst, PathIterator src) noexcept {
     dst.add_vertex(initial_cmd, src.vtx[0]);
 
   // Iterate the figure.
-  while (!(++src).at_end())
-    dst.add_vertex(src.cmd[0], src.vtx[0]);
+  while (!(++src).at_end()) {
+    if (src.cmd[0] == BL_PATH_CMD_CONIC)
+      dst.add_conic_control(src.vtx[0], src.conic_weight_data[0]);
+    else
+      dst.add_vertex(src.cmd[0], src.vtx[0]);
+  }
 
   return BL_SUCCESS;
 }
@@ -1943,7 +2025,10 @@ static BLResult join_reversed_figure(PathAppender& dst, PathIterator src) noexce
   // Iterate the figure.
   if (!src.at_end()) {
     do {
-      dst.add_vertex(src.cmd[0], src.vtx[0]);
+      if (src.cmd[0] == BL_PATH_CMD_CONIC)
+        dst.add_conic_control(src.vtx[0], src.conic_weight_data[0]);
+      else
+        dst.add_vertex(src.cmd[0], src.vtx[0]);
       src--;
     } while (!src.at_end());
     // Fix the last vertex to not be MOVE.
@@ -1964,7 +2049,7 @@ static BLResult append_stroked_path_sink(BLPathCore* a, BLPathCore* b, BLPathCor
   bl_unused(figure_start, figure_end, user_data);
 
   PathAppender dst;
-  BL_PROPAGATE(dst.begin(a, BL_MODIFY_OP_APPEND_GROW, b->dcast().size() + c->dcast().size() + 1u));
+  BL_PROPAGATE(dst.begin(a, BL_MODIFY_OP_APPEND_GROW, b->dcast().size() + c->dcast().size() + 1u, b->dcast().conic_weight_size() + c->dcast().conic_weight_size()));
 
   BLResult result = join_reversed_figure(dst, PathIterator(b->dcast().view()));
   result |= join_figure(dst, PathIterator(c->dcast().view()));
@@ -1994,7 +2079,7 @@ BL_API_IMPL BLResult bl_path_add_stroked_path(BLPathCore* self, const BLPathCore
   if (!approx)
     approx = &bl_default_approximation_options;
 
-  BLPathView input { other_impl->command_data + start, other_impl->vertex_data + start, n };
+  BLPathView input = make_view(other_impl, start, n);
   BLPath b_path;
   BLPath c_path;
 
@@ -2034,7 +2119,7 @@ BL_API_IMPL BLResult BL_CDECL bl_path_stroke_to_sink(
   if (!approximation_options)
     approximation_options = &bl_default_approximation_options;
 
-  BLPathView input { self_impl->command_data + start, self_impl->vertex_data + start, n };
+  BLPathView input = make_view(self_impl, start, n);
 
   if (a == self || b == self || c == self) {
     BLPath tmp(self->dcast());
@@ -2066,21 +2151,30 @@ BL_API_IMPL BLResult bl_path_remove_range(BLPathCore* self, const BLRange* range
 
   BLPoint* vtx_data = self_impl->vertex_data;
   uint8_t* cmd_data = self_impl->command_data;
+  double* conic_weight_data = self_impl->conic_weight_data;
+  size_t conic_start = count_conics(cmd_data, start);
+  size_t conic_end = count_conics(cmd_data, end);
+  size_t conic_count = conic_end - conic_start;
 
   size_t size_after = size - n;
+  size_t conic_size_after = self_impl->conic_weight_size - conic_count;
   if (!is_impl_mutable(self_impl)) {
     BLPathCore newO;
-    BL_PROPAGATE(alloc_impl(&newO, size_after, impl_size_from_capacity(size_after)));
+    BL_PROPAGATE(alloc_impl(&newO, size_after, conic_size_after, impl_size_from_capacity(size_after)));
 
     BLPathPrivateImpl* new_impl = get_impl(&newO);
     copy_content(new_impl->command_data, new_impl->vertex_data, cmd_data, vtx_data, start);
     copy_content(new_impl->command_data + start, new_impl->vertex_data + start, cmd_data + end, vtx_data + end, size - end);
+    copy_weights(new_impl->conic_weight_data, conic_weight_data, conic_start);
+    copy_weights(new_impl->conic_weight_data + conic_start, conic_weight_data + conic_end, self_impl->conic_weight_size - conic_end);
 
     return replace_instance(self, &newO);
   }
   else {
     copy_content(cmd_data + start, vtx_data + start, cmd_data + end, vtx_data + end, size - end);
+    copy_weights(conic_weight_data + conic_start, conic_weight_data + conic_end, self_impl->conic_weight_size - conic_end);
     self_impl->size = size_after;
+    self_impl->conic_weight_size = conic_size_after;
     self_impl->flags = BL_PATH_FLAG_DIRTY;
     return BL_SUCCESS;
   }
@@ -2153,7 +2247,7 @@ BL_API_IMPL BLResult bl_path_fit_to(BLPathCore* self, const BLRange* range, cons
     return bl_make_error(BL_ERROR_INVALID_VALUE);
 
   PathInfoUpdater updater;
-  BL_PROPAGATE(updater.update(BLPathView { self_impl->command_data + start, self_impl->vertex_data + start, n }, true));
+  BL_PROPAGATE(updater.update(make_view(self_impl, start, n), true));
 
   // TODO: Honor `fit_flags`.
   bl_unused(fit_flags);
@@ -2193,11 +2287,13 @@ BL_API_IMPL bool bl_path_equals(const BLPathCore* a, const BLPathCore* b) noexce
     return true;
 
   size_t size = a_impl->size;
-  if (size != b_impl->size)
+  size_t conic_weight_size = a_impl->conic_weight_size;
+  if (size != b_impl->size || conic_weight_size != b_impl->conic_weight_size)
     return false;
 
   return memcmp(a_impl->command_data, b_impl->command_data, size * sizeof(uint8_t)) == 0 &&
-         memcmp(a_impl->vertex_data , b_impl->vertex_data , size * sizeof(BLPoint)) == 0;
+         memcmp(a_impl->vertex_data , b_impl->vertex_data , size * sizeof(BLPoint)) == 0 &&
+         memcmp(a_impl->conic_weight_data, b_impl->conic_weight_data, conic_weight_size * sizeof(double)) == 0;
 }
 
 // bl::Path - API Path Info
@@ -2213,7 +2309,7 @@ static BL_NOINLINE BLResult update_info(BLPathPrivateImpl* self_impl) noexcept {
     return bl_make_error(BL_ERROR_INVALID_GEOMETRY);
 
   PathInfoUpdater updater;
-  BLResult result = updater.update(self_impl->view);
+  BLResult result = updater.update(make_view(self_impl, 0, self_impl->size));
 
   // Path is invalid.
   if (result != BL_SUCCESS) {
@@ -2447,6 +2543,7 @@ BL_API_IMPL BLHitTest bl_path_hit_test(const BLPathCore* self, const BLPoint* p_
 
   const uint8_t* cmd_data = self_impl->command_data;
   const BLPoint* vtx_data = self_impl->vertex_data;
+  const double* conic_weight_data = self_impl->conic_weight_data;
 
   bool has_move_to = false;
   BLPoint start {};
@@ -2582,6 +2679,62 @@ OnLine:
             }
           } while ((spline_ptr += 2) != spline_end);
         }
+        break;
+      }
+
+      case BL_PATH_CMD_CONIC: {
+        if (BL_UNLIKELY(!has_move_to || i < 2))
+          return BL_HIT_TEST_INVALID;
+
+        const BLPoint* p = vtx_data - 1;
+        double w = conic_weight_data[0];
+        double min_y = bl_min(p[0].y, p[1].y, p[2].y);
+        double max_y = bl_max(p[0].y, p[1].y, p[2].y);
+
+        cmd_data += 2;
+        vtx_data += 2;
+        conic_weight_data++;
+        i -= 2;
+
+        if (pt.y >= min_y && pt.y <= max_y) {
+          BLPoint prev = p[0];
+
+          for (uint32_t step = 1; step <= 8; step++) {
+            double t = double(step) * (1.0 / 8.0);
+            double u = 1.0 - t;
+            double a = u * u;
+            double b = 2.0 * w * u * t;
+            double c = t * t;
+            double d = 1.0 / (a + b + c);
+            BLPoint next = (a * p[0] + b * p[1] + c * p[2]) * d;
+
+            x0 = prev.x;
+            y0 = prev.y;
+            x1 = next.x;
+            y1 = next.y;
+
+            {
+              double dx = x1 - x0;
+              double dy = y1 - y0;
+
+              if (dy > 0.0) {
+                if (pt.y >= y0 && pt.y < y1) {
+                  double ix = x0 + (pt.y - y0) * dx / dy;
+                  winding_number += (pt.x >= ix);
+                }
+              }
+              else if (dy < 0.0) {
+                if (pt.y >= y1 && pt.y < y0) {
+                  double ix = x0 + (pt.y - y0) * dx / dy;
+                  winding_number -= (pt.x >= ix);
+                }
+              }
+            }
+
+            prev = next;
+          }
+        }
+
         break;
       }
 

--- a/blend2d/core/path.h
+++ b/blend2d/core/path.h
@@ -31,15 +31,8 @@ BL_DEFINE_ENUM(BLPathCmd) {
   //! Close path.
   BL_PATH_CMD_CLOSE = 5,
 
-  //! Conic weight.
-  //!
-  //! \note This is not a point. This is a pair of values from which only the first (x) is used to represent weight
-  //! as used by conic curve. The other value (y) is always set to NaN by Blend2D, but can be arbitrary as it has
-  //! no meaning.
-  BL_PATH_CMD_WEIGHT = 6,
-
   //! Maximum value of `BLPathCmd`.
-  BL_PATH_CMD_MAX_VALUE = 6
+  BL_PATH_CMD_MAX_VALUE = 5
 
   BL_FORCE_ENUM_UINT32(BL_PATH_CMD)
 };
@@ -218,15 +211,19 @@ struct BLApproximationOptions {
 struct BLPathView {
   const uint8_t* command_data;
   const BLPoint* vertex_data;
+  const double* conic_weight_data;
   size_t size;
+  size_t conic_weight_size;
 
 #ifdef __cplusplus
   BL_INLINE_NODEBUG void reset() noexcept { *this = BLPathView{}; }
 
-  BL_INLINE_NODEBUG void reset(const uint8_t* command_data_in, const BLPoint* vertex_data_in, size_t size_in) noexcept {
+  BL_INLINE_NODEBUG void reset(const uint8_t* command_data_in, const BLPoint* vertex_data_in, const double* conic_weight_data_in, size_t size_in, size_t conic_weight_size_in) noexcept {
     command_data = command_data_in;
     vertex_data = vertex_data_in;
+    conic_weight_data = conic_weight_data_in;
     size = size_in;
+    conic_weight_size = conic_weight_size_in;
   }
 #endif
 };
@@ -287,10 +284,12 @@ BL_API size_t BL_CDECL bl_path_get_size(const BLPathCore* self) BL_NOEXCEPT_C BL
 BL_API size_t BL_CDECL bl_path_get_capacity(const BLPathCore* self) BL_NOEXCEPT_C BL_PURE;
 BL_API const uint8_t* BL_CDECL bl_path_get_command_data(const BLPathCore* self) BL_NOEXCEPT_C BL_PURE;
 BL_API const BLPoint* BL_CDECL bl_path_get_vertex_data(const BLPathCore* self) BL_NOEXCEPT_C BL_PURE;
+BL_API const double* BL_CDECL bl_path_get_conic_weight_data(const BLPathCore* self) BL_NOEXCEPT_C BL_PURE;
+BL_API size_t BL_CDECL bl_path_get_conic_weight_size(const BLPathCore* self) BL_NOEXCEPT_C BL_PURE;
 BL_API BLResult BL_CDECL bl_path_clear(BLPathCore* self) BL_NOEXCEPT_C;
 BL_API BLResult BL_CDECL bl_path_shrink(BLPathCore* self) BL_NOEXCEPT_C;
 BL_API BLResult BL_CDECL bl_path_reserve(BLPathCore* self, size_t n) BL_NOEXCEPT_C;
-BL_API BLResult BL_CDECL bl_path_modify_op(BLPathCore* self, BLModifyOp op, size_t n, uint8_t** cmd_data_out, BLPoint** vtx_data_out) BL_NOEXCEPT_C;
+BL_API BLResult BL_CDECL bl_path_modify_op_ex(BLPathCore* self, BLModifyOp op, size_t n, size_t conic_weight_n, uint8_t** cmd_data_out, BLPoint** vtx_data_out, double** conic_weight_data_out) BL_NOEXCEPT_C;
 BL_API BLResult BL_CDECL bl_path_assign_move(BLPathCore* self, BLPathCore* other) BL_NOEXCEPT_C;
 BL_API BLResult BL_CDECL bl_path_assign_weak(BLPathCore* self, const BLPathCore* other) BL_NOEXCEPT_C;
 BL_API BLResult BL_CDECL bl_path_assign_deep(BLPathCore* self, const BLPathCore* other) BL_NOEXCEPT_C;
@@ -416,8 +415,12 @@ struct BLPathImpl BL_CLASS_INHERITS(BLObjectImpl) {
       uint8_t* command_data;
       //! Vertex data.
       BLPoint* vertex_data;
+      //! Conic weight data.
+      double* conic_weight_data;
       //! Vertex/command count.
       size_t size;
+      //! Conic weight count.
+      size_t conic_weight_size;
     };
     //! Path data as view.
     BLPathView view;
@@ -478,8 +481,14 @@ static BL_INLINE size_t path_segment_count(const T&) noexcept { return T::kVerte
 template<typename T, typename... Args>
 static BL_INLINE size_t path_segment_count(const T&, Args&&... args) noexcept { return T::kVertexCount + path_segment_count(BLInternal::forward<Args>(args)...); }
 
+template<typename T>
+static BL_INLINE size_t path_segment_conic_count(const T&) noexcept { return T::kConicCount; }
+template<typename T, typename... Args>
+static BL_INLINE size_t path_segment_conic_count(const T&, Args&&... args) noexcept { return T::kConicCount + path_segment_conic_count(BLInternal::forward<Args>(args)...); }
+
 template<typename T> void store_path_segment_cmd(uint8_t* cmd, const T& segment) noexcept = delete;
 template<typename T> void store_path_segment_vtx(BLPoint* vtx, const T& segment) noexcept = delete;
+template<typename T> void store_path_segment_w(double* w, const T& segment) noexcept = delete;
 
 template<typename T>
 static BL_INLINE void store_path_segments_cmd(uint8_t* cmd, const T& segment) noexcept { store_path_segment_cmd<T>(cmd, segment); }
@@ -497,6 +506,15 @@ template<typename T, typename... Args>
 static BL_INLINE void store_path_segments_vtx(BLPoint* vtx, const T& segment, Args&&... args) noexcept {
   store_path_segment_vtx<T>(vtx, segment);
   store_path_segments_vtx(vtx + T::kVertexCount, BLInternal::forward<Args>(args)...);
+}
+
+template<typename T>
+static BL_INLINE void store_path_segments_w(double* w, const T& segment) noexcept { store_path_segment_w<T>(w, segment); }
+
+template<typename T, typename... Args>
+static BL_INLINE void store_path_segments_w(double* w, const T& segment, Args&&... args) noexcept {
+  store_path_segment_w<T>(w, segment);
+  store_path_segments_w(w + T::kConicCount, BLInternal::forward<Args>(args)...);
 }
 
 } // {BLInternal}
@@ -601,6 +619,18 @@ public:
   [[nodiscard]]
   BL_INLINE_NODEBUG const BLPoint* vertex_data_end() const noexcept { return _impl()->vertex_data + _impl()->size; }
 
+  //! Returns path's conic weight data (read-only).
+  [[nodiscard]]
+  BL_INLINE_NODEBUG const double* conic_weight_data() const noexcept { return _impl()->conic_weight_data; }
+
+  //! Returns the number of stored conic weights.
+  [[nodiscard]]
+  BL_INLINE_NODEBUG size_t conic_weight_size() const noexcept { return _impl()->conic_weight_size; }
+
+  //! Returns the end of path's conic weight data (read-only).
+  [[nodiscard]]
+  BL_INLINE_NODEBUG const double* conic_weight_data_end() const noexcept { return _impl()->conic_weight_data + _impl()->conic_weight_size; }
+
   //! Returns path's command data (read-only).
   [[nodiscard]]
   BL_INLINE_NODEBUG const uint8_t* command_data() const noexcept { return _impl()->command_data; }
@@ -633,8 +663,8 @@ public:
     return bl_path_reserve(this, n);
   }
 
-  BL_INLINE_NODEBUG BLResult modify_op(BLModifyOp op, size_t n, uint8_t** cmd_data_out, BLPoint** vtx_data_out) noexcept {
-    return bl_path_modify_op(this, op, n, cmd_data_out, vtx_data_out);
+  BL_INLINE_NODEBUG BLResult modify_op_ex(BLModifyOp op, size_t n, size_t conic_weight_n, uint8_t** cmd_data_out, BLPoint** vtx_data_out, double** conic_weight_data_out) noexcept {
+    return bl_path_modify_op_ex(this, op, n, conic_weight_n, cmd_data_out, vtx_data_out, conic_weight_data_out);
   }
 
   BL_INLINE_NODEBUG BLResult assign(BLPathCore&& other) noexcept {
@@ -863,24 +893,35 @@ public:
 
   struct MoveTo {
     static inline constexpr uint32_t kVertexCount = 1;
+    static inline constexpr uint32_t kConicCount = 0;
 
     double x, y;
   };
 
   struct LineTo {
     static inline constexpr uint32_t kVertexCount = 1;
+    static inline constexpr uint32_t kConicCount = 0;
 
     double x, y;
   };
 
   struct QuadTo {
     static inline constexpr uint32_t kVertexCount = 2;
+    static inline constexpr uint32_t kConicCount = 0;
 
     double x0, y0, x1, y1;
   };
 
+  struct ConicTo {
+    static inline constexpr uint32_t kVertexCount = 2;
+    static inline constexpr uint32_t kConicCount = 1;
+
+    double x0, y0, x1, y1, w;
+  };
+
   struct CubicTo {
     static inline constexpr uint32_t kVertexCount = 3;
+    static inline constexpr uint32_t kConicCount = 0;
 
     double x0, y0, x1, y1, x2, y2;
   };
@@ -889,12 +930,15 @@ public:
   BL_INLINE BLResult add_segments(Args&&... args) noexcept {
     uint8_t* cmd_ptr;
     BLPoint* vtx_ptr;
+    double* conic_weight_ptr;
 
     size_t kVertexCount = BLInternal::path_segment_count(BLInternal::forward<Args>(args)...);
-    BL_PROPAGATE(modify_op(BL_MODIFY_OP_APPEND_GROW, kVertexCount, &cmd_ptr, &vtx_ptr));
+    size_t kConicCount = BLInternal::path_segment_conic_count(BLInternal::forward<Args>(args)...);
+    BL_PROPAGATE(modify_op_ex(BL_MODIFY_OP_APPEND_GROW, kVertexCount, kConicCount, &cmd_ptr, &vtx_ptr, &conic_weight_ptr));
 
     BLInternal::store_path_segments_cmd(cmd_ptr, BLInternal::forward<Args>(args)...);
     BLInternal::store_path_segments_vtx(vtx_ptr, BLInternal::forward<Args>(args)...);
+    BLInternal::store_path_segments_w(conic_weight_ptr, BLInternal::forward<Args>(args)...);
 
     return BL_SUCCESS;
   }
@@ -1364,6 +1408,9 @@ BL_INLINE void store_path_segment_cmd(uint8_t* cmd, const BLPath::MoveTo&) noexc
 }
 
 template<>
+BL_INLINE void store_path_segment_w(double*, const BLPath::MoveTo&) noexcept {}
+
+template<>
 BL_INLINE void store_path_segment_vtx(BLPoint* vtx, const BLPath::MoveTo& segment) noexcept {
   vtx[0] = BLPoint(segment.x, segment.y);
 }
@@ -1372,6 +1419,9 @@ template<>
 BL_INLINE void store_path_segment_cmd(uint8_t* cmd, const BLPath::LineTo&) noexcept {
   cmd[0] = uint8_t(BL_PATH_CMD_ON);
 }
+
+template<>
+BL_INLINE void store_path_segment_w(double*, const BLPath::LineTo&) noexcept {}
 
 template<>
 BL_INLINE void store_path_segment_vtx(BLPoint* vtx, const BLPath::LineTo& segment) noexcept {
@@ -1385,7 +1435,27 @@ BL_INLINE void store_path_segment_cmd(uint8_t* cmd, const BLPath::QuadTo&) noexc
 }
 
 template<>
+BL_INLINE void store_path_segment_w(double*, const BLPath::QuadTo&) noexcept {}
+
+template<>
 BL_INLINE void store_path_segment_vtx(BLPoint* vtx, const BLPath::QuadTo& segment) noexcept {
+  vtx[0] = BLPoint(segment.x0, segment.y0);
+  vtx[1] = BLPoint(segment.x1, segment.y1);
+}
+
+template<>
+BL_INLINE void store_path_segment_cmd(uint8_t* cmd, const BLPath::ConicTo&) noexcept {
+  cmd[0] = uint8_t(BL_PATH_CMD_CONIC);
+  cmd[1] = uint8_t(BL_PATH_CMD_ON);
+}
+
+template<>
+BL_INLINE void store_path_segment_w(double* w, const BLPath::ConicTo& segment) noexcept {
+  w[0] = segment.w;
+}
+
+template<>
+BL_INLINE void store_path_segment_vtx(BLPoint* vtx, const BLPath::ConicTo& segment) noexcept {
   vtx[0] = BLPoint(segment.x0, segment.y0);
   vtx[1] = BLPoint(segment.x1, segment.y1);
 }
@@ -1396,6 +1466,9 @@ BL_INLINE void store_path_segment_cmd(uint8_t* cmd, const BLPath::CubicTo&) noex
   cmd[1] = uint8_t(BL_PATH_CMD_CUBIC);
   cmd[2] = uint8_t(BL_PATH_CMD_ON);
 }
+
+template<>
+BL_INLINE void store_path_segment_w(double*, const BLPath::CubicTo&) noexcept {}
 
 template<>
 BL_INLINE void store_path_segment_vtx(BLPoint* vtx, const BLPath::CubicTo& segment) noexcept {

--- a/blend2d/core/path_p.h
+++ b/blend2d/core/path_p.h
@@ -33,11 +33,11 @@ namespace PathInternal {
 //! \{
 
 static BL_INLINE constexpr size_t capacity_from_impl_size(BLObjectImplSize impl_size) noexcept {
-  return (impl_size.value() - sizeof(BLPathPrivateImpl)) / (sizeof(BLPoint) + 1);
+  return (impl_size.value() - sizeof(BLPathPrivateImpl)) / (sizeof(BLPoint) + sizeof(double) + 1);
 }
 
 static BL_INLINE constexpr BLObjectImplSize impl_size_from_capacity(size_t capacity) noexcept {
-  return BLObjectImplSize(sizeof(BLPathPrivateImpl) + capacity * (sizeof(BLPoint) + 1));
+  return BLObjectImplSize(sizeof(BLPathPrivateImpl) + capacity * (sizeof(BLPoint) + sizeof(double) + 1));
 }
 
 //! \}
@@ -97,6 +97,13 @@ static BL_INLINE constexpr BLApproximationOptions make_default_approximation_opt
   };
 }
 
+static BL_INLINE size_t count_conics(const uint8_t* cmd_data, size_t n) noexcept {
+  size_t count = 0;
+  for (size_t i = 0; i < n; i++)
+    count += size_t(cmd_data[i] == BL_PATH_CMD_CONIC);
+  return count;
+}
+
 //! \}
 
 } // {PathPrivate}
@@ -109,19 +116,40 @@ struct PathIterator {
   const uint8_t* cmd;
   const uint8_t* end;
   const BLPoint* vtx;
+  const double* conic_weight_data;
 
   BL_INLINE PathIterator() noexcept = default;
   BL_INLINE PathIterator(const BLPathView& view) noexcept { reset(view); }
-  BL_INLINE PathIterator(const uint8_t* cmd_, const BLPoint* vtx_, size_t n) noexcept { reset(cmd_, vtx_, n); }
+  BL_INLINE PathIterator(const uint8_t* cmd_, const BLPoint* vtx_, const double* conic_weight_, size_t n) noexcept { reset(cmd_, vtx_, conic_weight_, n); }
 
-  BL_INLINE PathIterator operator++(int) noexcept { PathIterator out(*this); cmd++; vtx++; return out; }
-  BL_INLINE PathIterator operator--(int) noexcept { PathIterator out(*this); cmd--; vtx--; return out; }
+  BL_INLINE PathIterator operator++(int) noexcept { PathIterator out(*this); ++(*this); return out; }
+  BL_INLINE PathIterator operator--(int) noexcept { PathIterator out(*this); --(*this); return out; }
 
-  BL_INLINE PathIterator& operator++() noexcept { cmd++; vtx++; return *this; }
-  BL_INLINE PathIterator& operator--() noexcept { cmd--; vtx--; return *this; }
+  BL_INLINE PathIterator& operator++() noexcept {
+    conic_weight_data += size_t(cmd[0] == BL_PATH_CMD_CONIC);
+    cmd++;
+    vtx++;
+    return *this;
+  }
+  BL_INLINE PathIterator& operator--() noexcept {
+    cmd--;
+    vtx--;
+    conic_weight_data -= size_t(cmd[0] == BL_PATH_CMD_CONIC);
+    return *this;
+  }
 
-  BL_INLINE PathIterator& operator+=(size_t n) noexcept { cmd += n; vtx += n; return *this; }
-  BL_INLINE PathIterator& operator-=(size_t n) noexcept { cmd -= n; vtx -= n; return *this; }
+  BL_INLINE PathIterator& operator+=(size_t n) noexcept {
+    conic_weight_data += PathInternal::count_conics(cmd, n);
+    cmd += n;
+    vtx += n;
+    return *this;
+  }
+  BL_INLINE PathIterator& operator-=(size_t n) noexcept {
+    cmd -= n;
+    vtx -= n;
+    conic_weight_data -= PathInternal::count_conics(cmd, n);
+    return *this;
+  }
 
   BL_INLINE bool at_end() const noexcept { return cmd == end; }
   BL_INLINE bool after_end() const noexcept { return cmd > end; }
@@ -131,21 +159,25 @@ struct PathIterator {
   BL_INLINE size_t remaining_backward() const noexcept { return (size_t)(cmd - end); }
 
   BL_INLINE void reset(const BLPathView& view) noexcept {
-    reset(view.command_data, view.vertex_data, view.size);
+    reset(view.command_data, view.vertex_data, view.conic_weight_data, view.size);
   }
 
-  BL_INLINE void reset(const uint8_t* cmd_, const BLPoint* vtx_, size_t n) noexcept {
+  BL_INLINE void reset(const uint8_t* cmd_, const BLPoint* vtx_, const double* conic_weight_, size_t n) noexcept {
     cmd = cmd_;
     end = cmd_ + n;
     vtx = vtx_;
+    conic_weight_data = conic_weight_;
   }
 
   BL_INLINE void reverse() noexcept {
     intptr_t n = intptr_t(remaining_forward()) - 1;
+    const uint8_t* begin = cmd;
+    size_t conic_index = PathInternal::count_conics(begin, size_t(n + 1));
 
     end = cmd - 1;
     cmd += n;
     vtx += n;
+    conic_weight_data += conic_index - size_t(cmd[0] == BL_PATH_CMD_CONIC);
   }
 };
 
@@ -177,6 +209,7 @@ struct PathIterator {
 //!       case BL_PATH_CMD_MOVE : appender.move_to(iter[0]); break;
 //!       case BL_PATH_CMD_ON   : appender.line_to(iter[0]); break;
 //!       case BL_PATH_CMD_QUAD : appender.quad_to(iter[0], iter[1]); break;
+//!       case BL_PATH_CMD_CONIC: appender.conic_to(iter[0], iter[1], *iter.conic_weight_data); break;
 //!       case BL_PATH_CMD_CUBIC: appender.cubic_to(iter[0], iter[1], iter[2]); break;
 //!       case BL_PATH_CMD_CLOSE: appender.close(); break;
 //!     }
@@ -196,13 +229,16 @@ public:
   Cmd* cmd;
   Cmd* end;
   BLPoint* vtx;
+  double* conic_weight_data;
+  double* conic_weight_data_end;
 
   BL_INLINE PathAppender() noexcept
     : cmd(nullptr) {}
 
-  BL_INLINE void reset() noexcept { cmd = nullptr; }
+  BL_INLINE void reset() noexcept { cmd = nullptr; conic_weight_data = nullptr; conic_weight_data_end = nullptr; }
   BL_INLINE bool is_empty() const noexcept { return cmd == nullptr; }
   BL_INLINE size_t remaining_size() const noexcept { return (size_t)(end - cmd); }
+  BL_INLINE size_t remaining_conic_weight_size() const noexcept { return (size_t)(conic_weight_data_end - conic_weight_data); }
 
   BL_INLINE size_t current_index(const BLPath& dst) const noexcept {
     return (size_t)(cmd - reinterpret_cast<Cmd*>(PathInternal::get_impl(&dst)->command_data));
@@ -215,46 +251,56 @@ public:
     vtx += n;
   }
 
-  BL_INLINE BLResult begin(BLPathCore* dst, BLModifyOp op, size_t n) noexcept {
+  BL_INLINE BLResult begin(BLPathCore* dst, BLModifyOp op, size_t n, size_t conic_n = 0) noexcept {
     BLPoint* vtx_ptr_local;
     uint8_t* cmd_ptr_local;
-    BL_PROPAGATE(bl_path_modify_op(dst, op, n, &cmd_ptr_local, &vtx_ptr_local));
+    double* conic_weight_ptr_local;
+    BL_PROPAGATE(bl_path_modify_op_ex(dst, op, n, conic_n, &cmd_ptr_local, &vtx_ptr_local, &conic_weight_ptr_local));
 
     BLPathImpl* dst_impl = PathInternal::get_impl(dst);
     vtx = vtx_ptr_local;
     cmd = reinterpret_cast<Cmd*>(cmd_ptr_local);
     end = reinterpret_cast<Cmd*>(dst_impl->command_data + dst_impl->capacity);
+    conic_weight_data = conic_weight_ptr_local;
+    conic_weight_data_end = dst_impl->conic_weight_data + dst_impl->capacity;
 
     BL_ASSERT(remaining_size() >= n);
+    BL_ASSERT(remaining_conic_weight_size() >= conic_n);
     return BL_SUCCESS;
   }
 
-  BL_INLINE BLResult begin_assign(BLPathCore* dst, size_t n) noexcept { return begin(dst, BL_MODIFY_OP_ASSIGN_GROW, n); }
-  BL_INLINE BLResult begin_append(BLPathCore* dst, size_t n) noexcept { return begin(dst, BL_MODIFY_OP_APPEND_GROW, n); }
+  BL_INLINE BLResult begin_assign(BLPathCore* dst, size_t n, size_t conic_n = 0) noexcept { return begin(dst, BL_MODIFY_OP_ASSIGN_GROW, n, conic_n); }
+  BL_INLINE BLResult begin_append(BLPathCore* dst, size_t n, size_t conic_n = 0) noexcept { return begin(dst, BL_MODIFY_OP_APPEND_GROW, n, conic_n); }
 
-  BL_INLINE BLResult ensure(BLPathCore* dst, size_t n) noexcept {
-    if (BL_LIKELY(remaining_size() >= n))
+  BL_INLINE BLResult ensure(BLPathCore* dst, size_t n, size_t conic_n = 0) noexcept {
+    if (BL_LIKELY(remaining_size() >= n && remaining_conic_weight_size() >= conic_n))
       return BL_SUCCESS;
 
     BLPathImpl* dst_impl = PathInternal::get_impl(dst);
 
     dst_impl->size = (size_t)(reinterpret_cast<uint8_t*>(cmd) - dst_impl->command_data);
+    dst_impl->conic_weight_size = (size_t)(conic_weight_data - dst_impl->conic_weight_data);
     BL_ASSERT(dst_impl->size <= dst_impl->capacity);
 
     uint8_t* cmd_ptr_local;
     BLPoint* vtx_ptr_local;
-    BL_PROPAGATE(bl_path_modify_op(dst, BL_MODIFY_OP_APPEND_GROW, n, &cmd_ptr_local, &vtx_ptr_local));
+    double* conic_weight_ptr_local;
+    BL_PROPAGATE(bl_path_modify_op_ex(dst, BL_MODIFY_OP_APPEND_GROW, n, conic_n, &cmd_ptr_local, &vtx_ptr_local, &conic_weight_ptr_local));
 
     dst_impl = PathInternal::get_impl(dst);
     vtx = vtx_ptr_local;
     cmd = reinterpret_cast<Cmd*>(cmd_ptr_local);
     end = reinterpret_cast<Cmd*>(dst_impl->command_data + dst_impl->capacity);
+    conic_weight_data = conic_weight_ptr_local;
+    conic_weight_data_end = dst_impl->conic_weight_data + dst_impl->capacity;
 
     BL_ASSERT(remaining_size() >= n);
+    BL_ASSERT(remaining_conic_weight_size() >= conic_n);
     return BL_SUCCESS;
   }
 
   BL_INLINE void back(size_t n = 1) noexcept {
+    conic_weight_data -= PathInternal::count_conics(reinterpret_cast<const uint8_t*>(cmd - n), n);
     cmd -= n;
     vtx -= n;
   }
@@ -267,6 +313,7 @@ public:
     BL_ASSERT(new_size <= dst_impl->capacity);
 
     dst_impl->size = new_size;
+    dst_impl->conic_weight_size = (size_t)(conic_weight_data - dst_impl->conic_weight_data);
   }
 
   BL_INLINE void done(BLPathCore* dst) noexcept {
@@ -316,6 +363,8 @@ public:
     vtx += 2;
   }
 
+  // Cubic approximation
+  /*
   BL_INLINE void conic_to(const BLPoint& p1, const BLPoint& p2, double w) noexcept {
     BL_ASSERT(remaining_size() >= 3);
     double k = 4.0 * w / (3.0 * (1.0 + w));
@@ -332,27 +381,27 @@ public:
     cmd += 3;
     vtx += 3;
   }
+  */
 
-/*
-  // TODO [Conic]: Use this instead of cubic approximation
   BL_INLINE void conic_to(const BLPoint& p1, const BLPoint& p2, double w) noexcept {
-    quad_to(p1.x, p1.y, p2.x, p2.y);
+    conic_to(p1.x, p1.y, p2.x, p2.y, w);
   }
 
   BL_INLINE void conic_to(double x1, double y1, double x2, double y2, double w) noexcept {
-    BL_ASSERT(remaining_size() >= 3);
+    BL_ASSERT(remaining_size() >= 2);
+    BL_ASSERT(remaining_conic_weight_size() >= 1);
 
     cmd[0].value = BL_PATH_CMD_CONIC;
-    cmd[1].value = BL_PATH_CMD_WEIGHT;
-    cmd[2].value = BL_PATH_CMD_ON;
+    cmd[1].value = BL_PATH_CMD_ON;
     vtx[0].reset(x1, y1);
-    vtx[1].reset(w, bl::Math::nan<double>());
-    vtx[2].reset(x2, y2);
+    vtx[1].reset(x2, y2);
+    conic_weight_data[0] = w;
 
-    cmd += 3;
-    vtx += 3;
+    cmd += 2;
+    vtx += 2;
+    conic_weight_data += 1;
   }
-*/
+
   BL_INLINE void cubic_to(const BLPoint& p1, const BLPoint& p2, const BLPoint& p3) noexcept {
     return cubic_to(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y);
   }
@@ -372,19 +421,7 @@ public:
   }
 
   BL_INLINE void arc_quadrant_to(const BLPoint& p1, const BLPoint& p2) noexcept {
-    BL_ASSERT(remaining_size() >= 3);
-
-    cmd[0].value = BL_PATH_CMD_CUBIC;
-    cmd[1].value = BL_PATH_CMD_CUBIC;
-    cmd[2].value = BL_PATH_CMD_ON;
-
-    BLPoint p0 = vtx[-1];
-    vtx[0] = p0 + (p1 - p0) * Math::kKAPPA;
-    vtx[1] = p2 + (p1 - p2) * Math::kKAPPA;
-    vtx[2] = p2;
-
-    cmd += 3;
-    vtx += 3;
+    conic_to(p1, p2, Math::kSQRT_0p5);
   }
 
   BL_INLINE void add_vertex(uint8_t cmd_, const BLPoint& p) noexcept {
@@ -395,6 +432,19 @@ public:
 
     cmd++;
     vtx++;
+  }
+
+  BL_INLINE void add_conic_control(const BLPoint& p, double w) noexcept {
+    BL_ASSERT(remaining_size() >= 1);
+    BL_ASSERT(remaining_conic_weight_size() >= 1);
+
+    cmd[0].value = BL_PATH_CMD_CONIC;
+    vtx[0] = p;
+    conic_weight_data[0] = w;
+
+    cmd++;
+    vtx++;
+    conic_weight_data++;
   }
 
   BL_INLINE void add_vertex(uint8_t cmd_, double x, double y) noexcept {

--- a/blend2d/core/path_test.cpp
+++ b/blend2d/core/path_test.cpp
@@ -15,6 +15,22 @@
 namespace bl {
 namespace Tests {
 
+static void expect_box_eq(const BLBox& actual, const BLBox& expected) {
+  EXPECT_EQ(actual.x0, expected.x0);
+  EXPECT_EQ(actual.y0, expected.y0);
+  EXPECT_EQ(actual.x1, expected.x1);
+  EXPECT_EQ(actual.y1, expected.y1);
+}
+
+static size_t count_command(const BLPath& path, uint8_t cmd) {
+  size_t count = 0;
+
+  for (size_t i = 0; i < path.size(); i++)
+    count += size_t(path.command_data()[i] == cmd);
+
+  return count;
+}
+
 UNIT(path_allocation_strategy, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
   BLPath p;
   size_t kNumItems = 1000000;
@@ -33,6 +49,164 @@ UNIT(path_allocation_strategy, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
       capacity = p.capacity();
     }
   }
+}
+
+UNIT(path_conic_storage, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath p;
+  EXPECT_SUCCESS(p.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(p.conic_to(1.0, 2.0, 3.0, 4.0, 0.5));
+  EXPECT_SUCCESS(p.line_to(5.0, 6.0));
+
+  EXPECT_EQ(p.size(), size_t(4));
+  EXPECT_EQ(p.conic_weight_size(), size_t(1));
+
+  const uint8_t* cmd = p.command_data();
+  const BLPoint* vtx = p.vertex_data();
+  const double* w = p.conic_weight_data();
+
+  EXPECT_EQ(cmd[0], uint8_t(BL_PATH_CMD_MOVE));
+  EXPECT_EQ(cmd[1], uint8_t(BL_PATH_CMD_CONIC));
+  EXPECT_EQ(cmd[2], uint8_t(BL_PATH_CMD_ON));
+  EXPECT_EQ(cmd[3], uint8_t(BL_PATH_CMD_ON));
+
+  EXPECT_EQ(vtx[0], BLPoint(0.0, 0.0));
+  EXPECT_EQ(vtx[1], BLPoint(1.0, 2.0));
+  EXPECT_EQ(vtx[2], BLPoint(3.0, 4.0));
+  EXPECT_EQ(vtx[3], BLPoint(5.0, 6.0));
+  EXPECT_EQ(w[0], 0.5);
+}
+
+UNIT(path_conic_copy_and_reverse, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  EXPECT_SUCCESS(src.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(src.conic_to(1.0, 2.0, 3.0, 4.0, 0.75));
+
+  BLPath copy;
+  EXPECT_SUCCESS(copy.add_path(src));
+  EXPECT_TRUE(copy.equals(src));
+  EXPECT_EQ(copy.conic_weight_size(), size_t(1));
+  EXPECT_EQ(copy.conic_weight_data()[0], 0.75);
+
+  BLPath reversed;
+  EXPECT_SUCCESS(reversed.add_reversed_path(src, BL_PATH_REVERSE_MODE_COMPLETE));
+
+  EXPECT_EQ(reversed.size(), size_t(3));
+  EXPECT_EQ(reversed.conic_weight_size(), size_t(1));
+  EXPECT_EQ(reversed.command_data()[0], uint8_t(BL_PATH_CMD_MOVE));
+  EXPECT_EQ(reversed.command_data()[1], uint8_t(BL_PATH_CMD_CONIC));
+  EXPECT_EQ(reversed.command_data()[2], uint8_t(BL_PATH_CMD_ON));
+  EXPECT_EQ(reversed.vertex_data()[0], BLPoint(3.0, 4.0));
+  EXPECT_EQ(reversed.vertex_data()[1], BLPoint(1.0, 2.0));
+  EXPECT_EQ(reversed.vertex_data()[2], BLPoint(0.0, 0.0));
+  EXPECT_EQ(reversed.conic_weight_data()[0], 0.75);
+}
+
+UNIT(path_bounds_of_empty_path, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath path;
+  BLBox control_box;
+  BLBox bounding_box;
+
+  EXPECT_SUCCESS(path.get_control_box(&control_box));
+  EXPECT_SUCCESS(path.get_bounding_box(&bounding_box));
+
+  expect_box_eq(control_box, BLBox(0.0, 0.0, 0.0, 0.0));
+  expect_box_eq(bounding_box, BLBox(0.0, 0.0, 0.0, 0.0));
+}
+
+UNIT(path_bounds_of_line_and_multiple_figures, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath path;
+  BLBox control_box;
+  BLBox bounding_box;
+
+  EXPECT_SUCCESS(path.move_to(10.0, 10.0));
+  EXPECT_SUCCESS(path.line_to(20.0, 10.0));
+  EXPECT_SUCCESS(path.move_to(-5.0, -7.0));
+  EXPECT_SUCCESS(path.line_to(-3.0, 1.0));
+
+  EXPECT_SUCCESS(path.get_control_box(&control_box));
+  EXPECT_SUCCESS(path.get_bounding_box(&bounding_box));
+
+  expect_box_eq(control_box, BLBox(-5.0, -7.0, 20.0, 10.0));
+  expect_box_eq(bounding_box, BLBox(-5.0, -7.0, 20.0, 10.0));
+}
+
+UNIT(path_bounds_of_quadratic_curve, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath path;
+  BLBox control_box;
+  BLBox bounding_box;
+
+  EXPECT_SUCCESS(path.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(path.quad_to(2.0, 4.0, 4.0, 0.0));
+
+  EXPECT_SUCCESS(path.get_control_box(&control_box));
+  EXPECT_SUCCESS(path.get_bounding_box(&bounding_box));
+
+  expect_box_eq(control_box, BLBox(0.0, 0.0, 4.0, 4.0));
+  expect_box_eq(bounding_box, BLBox(0.0, 0.0, 4.0, 2.0));
+}
+
+UNIT(path_bounds_of_conic_curve, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath path;
+  BLBox control_box;
+  BLBox bounding_box;
+
+  EXPECT_SUCCESS(path.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(path.conic_to(2.0, 4.0, 4.0, 0.0, 1.0));
+
+  EXPECT_SUCCESS(path.get_control_box(&control_box));
+  EXPECT_SUCCESS(path.get_bounding_box(&bounding_box));
+
+  expect_box_eq(control_box, BLBox(0.0, 0.0, 4.0, 4.0));
+  expect_box_eq(bounding_box, BLBox(0.0, 0.0, 4.0, 2.0));
+}
+
+UNIT(path_bounds_of_cubic_curve, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath path;
+  BLBox control_box;
+  BLBox bounding_box;
+
+  EXPECT_SUCCESS(path.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(path.cubic_to(0.0, 3.0, 3.0, 3.0, 3.0, 0.0));
+
+  EXPECT_SUCCESS(path.get_control_box(&control_box));
+  EXPECT_SUCCESS(path.get_bounding_box(&bounding_box));
+
+  expect_box_eq(control_box, BLBox(0.0, 0.0, 3.0, 3.0));
+  expect_box_eq(bounding_box, BLBox(0.0, 0.0, 3.0, 2.25));
+}
+
+UNIT(path_stroke_of_line_with_round_caps_emits_conics, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath dst;
+  BLStrokeOptions options;
+
+  options.width = 4.0;
+  options.set_caps(BL_STROKE_CAP_ROUND);
+
+  EXPECT_SUCCESS(src.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(src.line_to(10.0, 0.0));
+  EXPECT_SUCCESS(dst.add_stroked_path(src, options, bl_default_approximation_options));
+
+  EXPECT_EQ(dst.conic_weight_size(), size_t(4));
+  EXPECT_EQ(count_command(dst, BL_PATH_CMD_CONIC), size_t(4));
+}
+
+UNIT(path_stroke_of_polyline_with_round_join_emits_conic, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath dst;
+  BLStrokeOptions options;
+
+  options.width = 4.0;
+  options.join = BL_STROKE_JOIN_ROUND;
+  options.set_caps(BL_STROKE_CAP_BUTT);
+
+  EXPECT_SUCCESS(src.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(src.line_to(10.0, 0.0));
+  EXPECT_SUCCESS(src.line_to(10.0, 10.0));
+  EXPECT_SUCCESS(dst.add_stroked_path(src, options, bl_default_approximation_options));
+
+  EXPECT_EQ(dst.conic_weight_size(), size_t(1));
+  EXPECT_EQ(count_command(dst, BL_PATH_CMD_CONIC), size_t(1));
 }
 
 } // {Tests}

--- a/blend2d/core/path_test.cpp
+++ b/blend2d/core/path_test.cpp
@@ -31,6 +31,50 @@ static size_t count_command(const BLPath& path, uint8_t cmd) {
   return count;
 }
 
+static void expect_point_near(const BLPoint& actual, const BLPoint& expected, double tolerance = 1e-9) {
+  EXPECT_TRUE(bl_abs(actual.x - expected.x) <= tolerance);
+  EXPECT_TRUE(bl_abs(actual.y - expected.y) <= tolerance);
+}
+
+static void expect_path_near(const BLPath& actual, const BLPath& expected, double tolerance = 1e-9) {
+  EXPECT_EQ(actual.size(), expected.size());
+  EXPECT_EQ(actual.conic_weight_size(), expected.conic_weight_size());
+
+  const uint8_t* actual_cmd = actual.command_data();
+  const uint8_t* expected_cmd = expected.command_data();
+  const BLPoint* actual_vtx = actual.vertex_data();
+  const BLPoint* expected_vtx = expected.vertex_data();
+
+  for (size_t i = 0; i < actual.size(); i++) {
+    EXPECT_EQ(actual_cmd[i], expected_cmd[i]);
+    if (actual_cmd[i] != BL_PATH_CMD_CLOSE)
+      expect_point_near(actual_vtx[i], expected_vtx[i], tolerance);
+  }
+
+  const double* actual_weights = actual.conic_weight_data();
+  const double* expected_weights = expected.conic_weight_data();
+  for (size_t i = 0; i < actual.conic_weight_size(); i++)
+    EXPECT_TRUE(bl_abs(actual_weights[i] - expected_weights[i]) <= tolerance);
+}
+
+struct StrokeSinkCapture {
+  BLPath a;
+  BLPath b;
+  BLPath c;
+  size_t call_count = 0;
+};
+
+static BLResult BL_CDECL capture_stroke_sink(BLPathCore* a, BLPathCore* b, BLPathCore* c, size_t input_start, size_t input_end, void* user_data) noexcept {
+  bl_unused(input_start, input_end);
+
+  StrokeSinkCapture* capture = static_cast<StrokeSinkCapture*>(user_data);
+  capture->a = a->dcast();
+  capture->b = b->dcast();
+  capture->c = c->dcast();
+  capture->call_count++;
+  return BL_SUCCESS;
+}
+
 UNIT(path_allocation_strategy, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
   BLPath p;
   size_t kNumItems = 1000000;
@@ -191,6 +235,40 @@ UNIT(path_stroke_of_line_with_round_caps_emits_conics, BL_TEST_GROUP_GEOMETRY_CO
   EXPECT_EQ(count_command(dst, BL_PATH_CMD_CONIC), size_t(4));
 }
 
+UNIT(path_stroke_of_zero_length_line_with_round_caps_emits_conics, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath dst;
+  BLStrokeOptions options;
+
+  options.width = 4.0;
+  options.set_caps(BL_STROKE_CAP_ROUND);
+
+  EXPECT_SUCCESS(src.move_to(3.0, 4.0));
+  EXPECT_SUCCESS(src.line_to(3.0, 4.0));
+  EXPECT_SUCCESS(dst.add_stroked_path(src, options, bl_default_approximation_options));
+
+  EXPECT_FALSE(dst.is_empty());
+  EXPECT_EQ(dst.conic_weight_size(), size_t(4));
+  EXPECT_EQ(count_command(dst, BL_PATH_CMD_CONIC), size_t(4));
+}
+
+UNIT(path_stroke_of_zero_length_closed_figure_with_round_caps_emits_conics, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath dst;
+  BLStrokeOptions options;
+
+  options.width = 4.0;
+  options.set_caps(BL_STROKE_CAP_ROUND);
+
+  EXPECT_SUCCESS(src.move_to(3.0, 4.0));
+  EXPECT_SUCCESS(src.close());
+  EXPECT_SUCCESS(dst.add_stroked_path(src, options, bl_default_approximation_options));
+
+  EXPECT_FALSE(dst.is_empty());
+  EXPECT_EQ(dst.conic_weight_size(), size_t(4));
+  EXPECT_EQ(count_command(dst, BL_PATH_CMD_CONIC), size_t(4));
+}
+
 UNIT(path_stroke_of_polyline_with_round_join_emits_conic, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
   BLPath src;
   BLPath dst;
@@ -207,6 +285,144 @@ UNIT(path_stroke_of_polyline_with_round_join_emits_conic, BL_TEST_GROUP_GEOMETRY
 
   EXPECT_EQ(dst.conic_weight_size(), size_t(1));
   EXPECT_EQ(count_command(dst, BL_PATH_CMD_CONIC), size_t(1));
+}
+
+UNIT(path_stroke_sink_uses_convex_side_for_round_join, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath a;
+  BLPath b;
+  BLPath c;
+  BLStrokeOptions options;
+  StrokeSinkCapture capture;
+
+  options.width = 4.0;
+  options.join = BL_STROKE_JOIN_ROUND;
+  options.set_caps(BL_STROKE_CAP_BUTT);
+
+  EXPECT_SUCCESS(src.move_to(0.0, 0.0));
+  EXPECT_SUCCESS(src.line_to(10.0, 0.0));
+  EXPECT_SUCCESS(src.line_to(10.0, 10.0));
+  EXPECT_SUCCESS(bl_path_stroke_to_sink(&src, nullptr, &options, &bl_default_approximation_options, &a, &b, &c, capture_stroke_sink, &capture));
+
+  EXPECT_EQ(capture.call_count, size_t(1));
+  EXPECT_EQ(count_command(capture.a, BL_PATH_CMD_CONIC), size_t(0));
+  EXPECT_EQ(count_command(capture.b, BL_PATH_CMD_CONIC), size_t(1));
+
+  expect_point_near(capture.a.vertex_data()[0], BLPoint(0.0, 2.0));
+  expect_point_near(capture.a.vertex_data()[1], BLPoint(10.0, 2.0));
+  expect_point_near(capture.a.vertex_data()[2], BLPoint(10.0, 0.0));
+  expect_point_near(capture.a.vertex_data()[3], BLPoint(8.0, 0.0));
+  expect_point_near(capture.a.vertex_data()[4], BLPoint(8.0, 10.0));
+
+  expect_point_near(capture.b.vertex_data()[0], BLPoint(0.0, -2.0));
+  expect_point_near(capture.b.vertex_data()[1], BLPoint(10.0, -2.0));
+  expect_point_near(capture.b.vertex_data()[2], BLPoint(12.0, -2.0));
+  expect_point_near(capture.b.vertex_data()[3], BLPoint(12.0, 0.0));
+  expect_point_near(capture.b.vertex_data()[4], BLPoint(12.0, 10.0));
+}
+
+UNIT(path_stroke_sink_round_join_does_not_flip_inside_out, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath a;
+  BLPath b;
+  BLPath c;
+  BLStrokeOptions options;
+  StrokeSinkCapture capture;
+
+  options.width = 4.0;
+  options.join = BL_STROKE_JOIN_ROUND;
+  options.set_caps(BL_STROKE_CAP_BUTT);
+
+  EXPECT_SUCCESS(src.move_to(998.121, 202.38));
+  EXPECT_SUCCESS(src.line_to(479.277, 467.463));
+  EXPECT_SUCCESS(src.line_to(692.554, 562.961));
+  EXPECT_SUCCESS(src.line_to(205.334, 471.029));
+  EXPECT_SUCCESS(bl_path_stroke_to_sink(&src, nullptr, &options, &bl_default_approximation_options, &a, &b, &c, capture_stroke_sink, &capture));
+
+  EXPECT_EQ(capture.call_count, size_t(1));
+  EXPECT_EQ(count_command(capture.a, BL_PATH_CMD_CONIC), size_t(2));
+  EXPECT_EQ(count_command(capture.b, BL_PATH_CMD_CONIC), size_t(2));
+
+  const BLPoint* b_vtx = capture.b.vertex_data();
+  EXPECT_TRUE(b_vtx[5].x > b_vtx[4].x);
+  EXPECT_TRUE(b_vtx[7].y > b_vtx[6].y);
+}
+
+UNIT(path_stroke_sink_miter_clip_uses_contour_direction, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath a;
+  BLPath b;
+  BLPath c;
+  BLStrokeOptions options;
+  StrokeSinkCapture capture;
+
+  options.width = 4.0;
+  options.join = BL_STROKE_JOIN_MITER_CLIP;
+  options.set_caps(BL_STROKE_CAP_BUTT);
+
+  EXPECT_SUCCESS(src.move_to(1014.58, 363.059));
+  EXPECT_SUCCESS(src.line_to(653.661, 405.843));
+  EXPECT_SUCCESS(src.line_to(1112.74, 384.599));
+  EXPECT_SUCCESS(src.line_to(716.64, 479.365));
+  EXPECT_SUCCESS(bl_path_stroke_to_sink(&src, nullptr, &options, &bl_default_approximation_options, &a, &b, &c, capture_stroke_sink, &capture));
+
+  EXPECT_EQ(capture.call_count, size_t(1));
+
+  const BLPoint* b_vtx = capture.b.vertex_data();
+
+  expect_point_near(b_vtx[6], BLPoint(1113.2053621143584, 386.54410619312154));
+  EXPECT_TRUE(b_vtx[4].x > b_vtx[6].x);
+  EXPECT_TRUE(b_vtx[5].x > b_vtx[6].x);
+}
+
+UNIT(path_stroke_of_low_limit_miter_bevel_matches_bevel, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath miter_bevel_dst;
+  BLPath bevel_dst;
+  BLStrokeOptions miter_bevel_options;
+  BLStrokeOptions bevel_options;
+
+  miter_bevel_options.width = 4.0;
+  miter_bevel_options.join = BL_STROKE_JOIN_MITER_BEVEL;
+  miter_bevel_options.miter_limit = 0.5;
+  miter_bevel_options.set_caps(BL_STROKE_CAP_BUTT);
+
+  bevel_options = miter_bevel_options;
+  bevel_options.join = BL_STROKE_JOIN_BEVEL;
+
+  EXPECT_SUCCESS(src.move_to(960.277, 72.7924));
+  EXPECT_SUCCESS(src.line_to(434.98, 51.1125));
+  EXPECT_SUCCESS(src.line_to(493.827, 130.201));
+  EXPECT_SUCCESS(src.line_to(683.779, 88.4622));
+  EXPECT_SUCCESS(miter_bevel_dst.add_stroked_path(src, miter_bevel_options, bl_default_approximation_options));
+  EXPECT_SUCCESS(bevel_dst.add_stroked_path(src, bevel_options, bl_default_approximation_options));
+
+  expect_path_near(miter_bevel_dst, bevel_dst);
+}
+
+UNIT(path_stroke_of_low_limit_miter_round_matches_round, BL_TEST_GROUP_GEOMETRY_CONTAINERS) {
+  BLPath src;
+  BLPath miter_round_dst;
+  BLPath round_dst;
+  BLStrokeOptions miter_round_options;
+  BLStrokeOptions round_options;
+
+  miter_round_options.width = 4.0;
+  miter_round_options.join = BL_STROKE_JOIN_MITER_ROUND;
+  miter_round_options.miter_limit = 0.5;
+  miter_round_options.set_caps(BL_STROKE_CAP_BUTT);
+
+  round_options = miter_round_options;
+  round_options.join = BL_STROKE_JOIN_ROUND;
+
+  EXPECT_SUCCESS(src.move_to(960.277, 72.7924));
+  EXPECT_SUCCESS(src.line_to(434.98, 51.1125));
+  EXPECT_SUCCESS(src.line_to(493.827, 130.201));
+  EXPECT_SUCCESS(src.line_to(683.779, 88.4622));
+  EXPECT_SUCCESS(miter_round_dst.add_stroked_path(src, miter_round_options, bl_default_approximation_options));
+  EXPECT_SUCCESS(round_dst.add_stroked_path(src, round_options, bl_default_approximation_options));
+
+  expect_path_near(miter_round_dst, round_dst);
 }
 
 } // {Tests}

--- a/blend2d/core/pathstroke.cpp
+++ b/blend2d/core/pathstroke.cpp
@@ -12,7 +12,6 @@
 #include <blend2d/support/math_p.h>
 
 #include <limits>
-#include <utility>
 
 namespace bl {
 namespace PathInternal {
@@ -696,8 +695,7 @@ public:
     double a_sign = Geometry::dot(a_ref.vtx[-1] - pivot, before_unit) < 0.0 ? -1.0 : 1.0;
 
     if (a_sign != outer_sign) {
-      using std::swap;
-      swap(selection.outer, selection.inner);
+      bl::swap(selection.outer, selection.inner);
     }
 
     selection.before *= outer_sign;

--- a/blend2d/core/pathstroke.cpp
+++ b/blend2d/core/pathstroke.cpp
@@ -27,12 +27,14 @@ static constexpr double kStrokeLengthEpsilon = 1e-10;
 static constexpr double kStrokeLengthEpsilonSq = Math::square(kStrokeLengthEpsilon);
 
 static constexpr double kStrokeCollinearityEpsilon = 1e-10;
+static constexpr double kStrokeCollinearityEpsilonSq = Math::square(kStrokeCollinearityEpsilon);
 
 static constexpr double kStrokeCuspTThreshold = 1e-10;
 static constexpr double kStrokeDegenerateFlatness = 1e-6;
 
 // Epsilon used to split quadratic bezier curves during offsetting.
 static constexpr double kOffsetQuadEpsilonT = 1e-5;
+static constexpr uint32_t kApproxCurveMaxDepth = 16;
 
 // Minimum vertices that would be required for any join + additional line.
 //
@@ -40,7 +42,7 @@ static constexpr double kOffsetQuadEpsilonT = 1e-5;
 //   JOIN:
 //     bevel: 1 vertex
 //     miter: 3 vertices
-//     round: 7 vertices (2 cubics at most)
+//     round: 4 vertices (2 conics at most)
 //   ADDITIONAL:
 //     end-point: 1 vertex
 //     line-to  : 1 vertex
@@ -52,16 +54,26 @@ static constexpr size_t kStrokeMaxJoinVertices = 9;
 struct CapVertexCountGen {
   static constexpr uint8_t value(size_t cap) noexcept {
     return BLStrokeCap(cap) == BL_STROKE_CAP_SQUARE       ? 3 :
-           BLStrokeCap(cap) == BL_STROKE_CAP_ROUND        ? 6 :
-           BLStrokeCap(cap) == BL_STROKE_CAP_ROUND_REV    ? 8 :
+           BLStrokeCap(cap) == BL_STROKE_CAP_ROUND        ? 4 :
+           BLStrokeCap(cap) == BL_STROKE_CAP_ROUND_REV    ? 6 :
            BLStrokeCap(cap) == BL_STROKE_CAP_TRIANGLE     ? 2 :
            BLStrokeCap(cap) == BL_STROKE_CAP_TRIANGLE_REV ? 4 :
            BLStrokeCap(cap) == BL_STROKE_CAP_BUTT         ? 1 : 0;
   }
 };
 
+struct CapConicCountGen {
+  static constexpr uint8_t value(size_t cap) noexcept {
+    return BLStrokeCap(cap) == BL_STROKE_CAP_ROUND     ? 2 :
+           BLStrokeCap(cap) == BL_STROKE_CAP_ROUND_REV ? 2 : 0;
+  }
+};
+
 static constexpr auto cap_vertex_count_table =
   make_lookup_table<uint8_t, BL_STROKE_CAP_MAX_VALUE + 1, CapVertexCountGen>();
+
+static constexpr auto cap_conic_count_table =
+  make_lookup_table<uint8_t, BL_STROKE_CAP_MAX_VALUE + 1, CapConicCountGen>();
 
 // bl::Path - Stroke - Utilities
 // =============================
@@ -104,17 +116,21 @@ static BL_INLINE bool test_inner_join_intersecion(const BLPoint& a0, const BLPoi
          (join.x <= max.x) & (join.y <= max.y) ;
 }
 
-static BL_INLINE void dull_angle_arc_to(PathAppender& appender, const BLPoint& p0, const BLPoint& pa, const BLPoint& pb, const BLPoint& intersection) noexcept {
+static BL_INLINE void angle_arc_to(PathAppender& appender, const BLPoint& p0, const BLPoint& pa, const BLPoint& pb, const BLPoint& intersection) noexcept {
   BLPoint pm = (pa + pb) * 0.5;
 
-  double w = Math::sqrt(Geometry::magnitude(p0 - pm) / Geometry::magnitude(p0 - intersection));
-  double a = 4 * w / (3.0 * (1.0 + w));
+  double denominator = Geometry::magnitude(p0 - intersection);
+  if (!(denominator > 0.0))
+    return appender.line_to(pb);
 
-  BLPoint c0 = pa + a * (intersection - pa);
-  BLPoint c1 = pb + a * (intersection - pb);
+  double w = Math::sqrt(Geometry::magnitude(p0 - pm) / denominator);
+  if (!(w > 0.0) || !Math::is_finite(w))
+    return appender.line_to(pb);
 
-  appender.cubic_to(c0, c1, pb);
+  appender.conic_to(intersection, pb, w);
 };
+
+static constexpr size_t kStrokeMaxJoinConics = 2;
 
 // bl::Path - Stroke - Implementation
 // ==================================
@@ -214,15 +230,17 @@ public:
   BL_INLINE PathAppender& outer_appender(Side side) noexcept { return _side_data[size_t(side)].appender; }
   BL_INLINE PathAppender& inner_appender(Side side) noexcept { return _side_data[size_t(opposite_side(side))].appender; }
 
-  BL_INLINE BLResult ensure_appenders_capacity(size_t a_required, size_t b_required) noexcept {
+  BL_INLINE BLResult ensure_appenders_capacity(size_t a_required, size_t b_required, size_t a_conic_required = 0, size_t b_conic_required = 0) noexcept {
     uint32_t ok = uint32_t(a_out().remaining_size() >= a_required) &
-                  uint32_t(b_out().remaining_size() >= b_required) ;
+                  uint32_t(b_out().remaining_size() >= b_required) &
+                  uint32_t(a_out().remaining_conic_weight_size() >= a_conic_required) &
+                  uint32_t(b_out().remaining_conic_weight_size() >= b_conic_required) ;
 
     if (BL_LIKELY(ok))
       return BL_SUCCESS;
 
-    return a_out().ensure(a_path(), a_required) |
-           b_out().ensure(b_path(), b_required) ;
+    return a_out().ensure(a_path(), a_required, a_conic_required) |
+           b_out().ensure(b_path(), b_required, b_conic_required) ;
   }
 
   BL_INLINE_IF_NOT_DEBUG BLResult stroke(BLPathStrokeSinkFunc sink, void* user_data) noexcept {
@@ -249,7 +267,7 @@ public:
       BL_PROPAGATE(a_out().begin(a_path(), BL_MODIFY_OP_APPEND_GROW, _iter.remaining_forward()));
       BL_PROPAGATE(b_out().begin(b_path(), BL_MODIFY_OP_ASSIGN_GROW, 48));
 
-      BLPoint poly_pts[4];
+      BLPoint poly_pts[16];
       size_t poly_size;
 
       _p0 = *_iter.vtx;
@@ -259,7 +277,7 @@ public:
       // Content of the figure.
       _iter++;
       while (!_iter.at_end()) {
-        BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices));
+        BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
 
         uint8_t cmd = _iter.cmd[0]; // Next command.
         BLPoint p1 = _iter.vtx[0];  // Next line-to or control point.
@@ -286,7 +304,7 @@ LineTo:
             if (_iter.at_end())
               break;
 
-            BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices));
+            BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
 
             cmd = _iter.cmd[0];
             p1 = _iter.vtx[0];
@@ -359,6 +377,81 @@ SmoothPolyTo:
             BL_PROPAGATE(join_curve(n1));
 
           BL_PROPAGATE(offset_quad(_iter.vtx - 3));
+        }
+        else if (cmd == BL_PATH_CMD_CONIC) {
+          double w = _iter.conic_weight_data[0];
+          _iter += 2;
+          if (BL_UNLIKELY(_iter.after_end()))
+            return BL_ERROR_INVALID_GEOMETRY;
+
+          if (w == 1.0) {
+            BLPoint quad[3];
+            BLPoint p2 = _iter.vtx[-1];
+            BLPoint v2 = p2 - _iter.vtx[-2];
+
+            quad[0] = _p0;
+            quad[1] = _iter.vtx[-2];
+            quad[2] = p2;
+
+            v1 = quad[1] - _p0;
+            n1 = Geometry::normal(Geometry::unit_vector(v1));
+
+            double cm = Geometry::cross(v2, v1);
+            if (bl_abs(cm) <= kStrokeCollinearityEpsilon) {
+              double dot = Geometry::dot(-v1, v2);
+
+              if (dot > 0.0) {
+                double r1 = Geometry::dot(quad[1] - _p0, v1);
+                double r2 = Geometry::dot(quad[2] - _p0, v1);
+
+                double t = r1 / (2.0 * r1 - r2);
+                if (t > 0.0 && t < 1.0) {
+                  poly_pts[0] = Geometry::evaluate(Geometry::quad_ref(quad), t);
+                  poly_pts[1] = p2;
+                  poly_size = 2;
+                  goto SmoothPolyTo;
+                }
+              }
+
+              p1 = p2;
+              goto LineTo;
+            }
+
+            if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq || Geometry::magnitude_squared(v2) < kStrokeLengthEpsilonSq) {
+              p1 = p2;
+              goto LineTo;
+            }
+
+            if (!is_open())
+              BL_PROPAGATE(open_curve(n1));
+            else
+              BL_PROPAGATE(join_curve(n1));
+
+            BL_PROPAGATE(offset_quad(quad));
+            continue;
+          }
+
+          BLPoint conic[4];
+          conic[0] = _p0;
+          conic[1] = _iter.vtx[-2];
+          conic[2].reset(w, Math::nan<double>());
+          conic[3] = _iter.vtx[-1];
+
+          v1 = (conic[1] - _p0) * w;
+          if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
+            v1 = conic[3] - _p0;
+
+          if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
+            continue;
+
+          n1 = Geometry::normal(Geometry::unit_vector(v1));
+
+          if (!is_open())
+            BL_PROPAGATE(open_curve(n1));
+          else
+            BL_PROPAGATE(join_curve(n1));
+
+          BL_PROPAGATE(offset_conic(conic));
         }
         else if (cmd == BL_PATH_CMD_CUBIC) {
           // Cubic curve segment.
@@ -445,7 +538,7 @@ SmoothPolyTo:
             if (cusp <= 0)
               break;
 
-            BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices));
+            BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
 
             // Second part of the cubic after the cusp. We assign `-1` to `cusp` so we can call `join_cusp()` later.
             // This is a special join that we need in this case.
@@ -487,7 +580,7 @@ SmoothPolyTo:
         // A and B have a content, path C will be empty and should be thus ignored by the sink.
 
         // Allocate space for the end join and close command.
-        BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices + 1, kStrokeMaxJoinVertices + 1));
+        BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices + 1, kStrokeMaxJoinVertices + 1, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
 
         BL_PROPAGATE(join_end_point(_nInitial));
         a_out().close();
@@ -502,11 +595,11 @@ SmoothPolyTo:
         uint32_t start_cap = sanity_stroke_cap(_options.start_cap);
         uint32_t end_cap = sanity_stroke_cap(_options.end_cap);
 
-        BL_PROPAGATE(a_out().ensure(a_path(), cap_vertex_count_table[end_cap]));
+        BL_PROPAGATE(a_out().ensure(a_path(), cap_vertex_count_table[end_cap], cap_conic_count_table[end_cap]));
         BL_PROPAGATE(add_cap(a_out(), _p0, b_out().vtx[-1], end_cap));
 
         PathAppender c_out;
-        BL_PROPAGATE(c_out.begin(c_path(), BL_MODIFY_OP_ASSIGN_GROW, cap_vertex_count_table[start_cap] + 1));
+        BL_PROPAGATE(c_out.begin(c_path(), BL_MODIFY_OP_ASSIGN_GROW, cap_vertex_count_table[start_cap] + 1, cap_conic_count_table[start_cap]));
         c_out.move_to(b_path()->vertex_data()[0]);
         BL_PROPAGATE(add_cap(c_out, _pInitial, a_path()->vertex_data()[side_data(Side::kA).figure_offset], start_cap));
         c_out.done(c_path());
@@ -807,21 +900,12 @@ SmoothPolyTo:
         BLPoint pp1 = _p0 + q;
         BLPoint pc2 = Math::lerp(pc1, pp1, 2.0);
 
-        dull_angle_arc_to(appender, _p0, pa, pp1, pc1);
-        dull_angle_arc_to(appender, _p0, pp1, pb, pc2);
+        angle_arc_to(appender, _p0, pa, pp1, pc1);
+        angle_arc_to(appender, _p0, pp1, pb, pc2);
       }
       else {
         // Acute angle.
-        BLPoint pm = Math::lerp(pa, pb);
-        BLPoint pi = _p0 + k;
-
-        double w = Math::sqrt(Geometry::length(_p0, pm) / Geometry::length(_p0, pi));
-        double a = 4.0 * w / (3.0 * (1.0 + w));
-
-        BLPoint c0 = pa + a * (pi - pa);
-        BLPoint c1 = pb + a * (pi - pb);
-
-        appender.cubic_to(c0, c1, pb);
+        angle_arc_to(appender, _p0, pa, pb, _p0 + k);
       }
       return BL_SUCCESS;
     }
@@ -848,8 +932,8 @@ SmoothPolyTo:
     BLPoint pp1 = _p0 + q;
     BLPoint pc2 = Math::lerp(pc1, pp1, 2.0);
 
-    dull_angle_arc_to(out, _p0, pa, pp1, pc1);
-    dull_angle_arc_to(out, _p0, pp1, pb, pc2);
+    angle_arc_to(out, _p0, pa, pp1, pc1);
+    angle_arc_to(out, _p0, pp1, pb, pc2);
     return BL_SUCCESS;
   }
 
@@ -902,6 +986,114 @@ SmoothPolyTo:
     b_out().quad_to(p1 - k1, p2 - k2);
   }
 
+  static BL_INLINE BLPoint evaluate_projective_conic(const BLPoint proj[6], double t) noexcept {
+    BLPoint q01 = Math::lerp(proj[0], proj[2], t);
+    BLPoint w01 = Math::lerp(proj[1], proj[3], t);
+    BLPoint q12 = Math::lerp(proj[2], proj[4], t);
+    BLPoint w12 = Math::lerp(proj[3], proj[5], t);
+    BLPoint q012 = Math::lerp(q01, q12, t);
+    BLPoint w012 = Math::lerp(w01, w12, t);
+
+    return q012 / w012.x;
+  }
+
+  static BL_INLINE void approximate_projective_conic_with_quad(const BLPoint proj[6], BLPoint quad[3]) noexcept {
+    BLPoint p0 = proj[0] / proj[1].x;
+    BLPoint p2 = proj[4] / proj[5].x;
+
+    BLPoint v0 = proj[2] * proj[1].x - proj[0] * proj[3].x;
+    BLPoint v1 = proj[4] * proj[3].x - proj[2] * proj[5].x;
+    double v0m2 = Geometry::magnitude_squared(v0);
+    double v1m2 = Geometry::magnitude_squared(v1);
+    double cross = Geometry::cross(v0, v1);
+
+    quad[0] = p0;
+    quad[2] = p2;
+
+    if (v0m2 > kStrokeLengthEpsilonSq && v1m2 > kStrokeLengthEpsilonSq && Math::square(cross) > kStrokeCollinearityEpsilonSq * v0m2 * v1m2) {
+      quad[1] = Geometry::line_vector_intersection(p0, v0, p2, -v1);
+    }
+    else {
+      BLPoint pm = evaluate_projective_conic(proj, 0.5);
+      quad[1] = pm * 2.0 - (p0 + p2) * 0.5;
+    }
+  }
+
+  template<typename Callback>
+  BL_INLINE_IF_NOT_DEBUG BLResult approximate_conic_with_quads(const BLPoint conic[4], const Callback& callback) noexcept {
+    struct ConicApproximationPart {
+      BLPoint proj[6];
+      uint32_t depth;
+    };
+
+    BLPoint spline[30];
+    BLPoint projective[6];
+    BLPoint* spline_ptr = spline;
+    BLPoint* spline_end = Geometry::split_conic_to_spline<Geometry::QuadSplitOptions::kExtremaXY>(conic, spline_ptr);
+
+    if (spline_end == spline_ptr) {
+      Geometry::get_conic_projective_points(conic, projective);
+      spline_ptr = projective;
+      spline_end = projective + 6;
+    }
+
+    double tolerance_sq = Math::square(4.0 * _approx.simplify_tolerance);
+    ConicApproximationPart stack[kApproxCurveMaxDepth + 1];
+
+    do {
+      size_t stack_size = 1;
+      for (size_t i = 0; i < 6; i++)
+        stack[0].proj[i] = spline_ptr[i];
+      stack[0].depth = 0;
+
+      while (stack_size) {
+        ConicApproximationPart part = stack[--stack_size];
+        BLPoint quad[3];
+
+        approximate_projective_conic_with_quad(part.proj, quad);
+
+        BLPoint pm0 = evaluate_projective_conic(part.proj, 0.5);
+        BLPoint pm1 = Geometry::evaluate_precise(Geometry::quad_ref(quad), 0.5);
+
+        if (part.depth < kApproxCurveMaxDepth && Geometry::magnitude_squared(pm0 - pm1) > tolerance_sq) {
+          BLPoint left[6];
+          BLPoint right[6];
+
+          Geometry::split_projective_conic(part.proj, left, right, 0.5);
+
+          for (size_t i = 0; i < 6; i++) {
+            stack[stack_size].proj[i] = right[i];
+            stack[stack_size + 1].proj[i] = left[i];
+          }
+          stack[stack_size].depth = part.depth + 1;
+          stack[stack_size + 1].depth = part.depth + 1;
+          stack_size += 2;
+          continue;
+        }
+
+        BL_PROPAGATE(callback(quad));
+      }
+    } while ((spline_ptr += 6) != spline_end);
+
+    return BL_SUCCESS;
+  }
+
+  struct ConicApproximateSink {
+    PathStroker& _stroker;
+
+    BL_INLINE ConicApproximateSink(PathStroker& stroker) noexcept
+      : _stroker(stroker) {}
+
+    BL_INLINE BLResult operator()(const BLPoint quad[3]) const noexcept {
+      return _stroker.offset_quad(quad);
+    }
+  };
+
+  BL_INLINE_IF_NOT_DEBUG BLResult offset_conic(const BLPoint conic[4]) noexcept {
+    ConicApproximateSink sink(*this);
+    return approximate_conic_with_quads(conic, sink);
+  }
+
   struct CubicApproximateSink {
     PathStroker& _stroker;
 
@@ -915,7 +1107,7 @@ SmoothPolyTo:
 
   BL_INLINE_IF_NOT_DEBUG BLResult offset_cubic(const BLPoint bez[4]) noexcept {
     CubicApproximateSink sink(*this);
-    return Geometry::approximate_cubic_with_quads(Geometry::cubic_ref(bez), _approx.simplify_tolerance, sink);
+    return Geometry::approximate_cubic_with_quads(Geometry::cubic_ref(bez), _approx.simplify_tolerance, kApproxCurveMaxDepth, sink);
   }
 
   BL_INLINE_IF_NOT_DEBUG BLResult add_cap(PathAppender& out, BLPoint pivot, BLPoint p1, uint32_t cap_type) noexcept {

--- a/blend2d/core/pathstroke.cpp
+++ b/blend2d/core/pathstroke.cpp
@@ -11,42 +11,30 @@
 #include <blend2d/support/lookuptable_p.h>
 #include <blend2d/support/math_p.h>
 
+#include <limits>
+#include <utility>
+
 namespace bl {
 namespace PathInternal {
 
 // bl::Path - Stroke - Constants
 // =============================
 
-// Default minimum miter-join length that always bypasses any other join-type. The reason behind this is to
-// prevent emitting very small line segments in case that normals of joining segments are almost equal.
-static constexpr double kStrokeMiterMinimum = 1e-10;
-static constexpr double kStrokeMiterMinimumSq = Math::square(kStrokeMiterMinimum);
-
-// Minimum length for a line/curve the stroker will accept. If the segment is smaller than this it would be skipped.
 static constexpr double kStrokeLengthEpsilon = 1e-10;
 static constexpr double kStrokeLengthEpsilonSq = Math::square(kStrokeLengthEpsilon);
 
-static constexpr double kStrokeCollinearityEpsilon = 1e-10;
-static constexpr double kStrokeCollinearityEpsilonSq = Math::square(kStrokeCollinearityEpsilon);
+static constexpr double kStrokeJoinEpsilon = 1e-10;
+static constexpr double kStrokeOneOverSqrt2 = 0.70710678118654752440;
 
-static constexpr double kStrokeCuspTThreshold = 1e-10;
-static constexpr double kStrokeDegenerateFlatness = 1e-6;
+static constexpr uint32_t kStrokeTangentRecursiveLimit = 15u;
+static constexpr uint32_t kStrokeCubicRecursiveLimit = 24u;
+static constexpr uint32_t kStrokeConicRecursiveLimit = 33u;
+static constexpr uint32_t kStrokeQuadRecursiveLimit = 33u;
 
-// Epsilon used to split quadratic bezier curves during offsetting.
-static constexpr double kOffsetQuadEpsilonT = 1e-5;
-static constexpr uint32_t kApproxCurveMaxDepth = 16;
-
-// Minimum vertices that would be required for any join + additional line.
-//
-// Calculated from:
-//   JOIN:
-//     bevel: 1 vertex
-//     miter: 3 vertices
-//     round: 4 vertices (2 conics at most)
-//   ADDITIONAL:
-//     end-point: 1 vertex
-//     line-to  : 1 vertex
 static constexpr size_t kStrokeMaxJoinVertices = 9;
+static constexpr size_t kStrokeMaxJoinConics = 2;
+static constexpr size_t kStrokeCircleVertices = 10;
+static constexpr size_t kStrokeCircleConics = 4;
 
 // bl::Path - Stroke - Tables
 // ==========================
@@ -78,1083 +66,1624 @@ static constexpr auto cap_conic_count_table =
 // bl::Path - Stroke - Utilities
 // =============================
 
-enum class Side : size_t {
-  kA = 0,
-  kB = 1
+enum class StrokeType : int {
+  kOuter = 1,
+  kInner = -1
 };
 
-static BL_INLINE Side opposite_side(Side side) noexcept { return Side(size_t(1) - size_t(side)); }
+enum class AngleType : uint32_t {
+  kNearly180,
+  kSharp,
+  kShallow,
+  kNearlyLine
+};
 
-static BL_INLINE Side side_from_normals(const BLPoint& n0, const BLPoint& n1) noexcept {
-  return Side(size_t(Geometry::cross(n0, n1) >= 0));
+enum class ReductionType : uint32_t {
+  kPoint,
+  kLine,
+  kQuad,
+  kDegenerate,
+  kDegenerate2,
+  kDegenerate3
+};
+
+enum class ResultType : uint32_t {
+  kSplit,
+  kDegenerate,
+  kQuad
+};
+
+enum class IntersectRayType : uint32_t {
+  kCtrlPt,
+  kResultType
+};
+
+struct QuadConstruct {
+  BLPoint quad[3];
+  BLPoint tangent_start;
+  BLPoint tangent_end;
+  double start_t;
+  double mid_t;
+  double end_t;
+  bool start_set;
+  bool end_set;
+  bool opposite_tangents;
+
+  BL_INLINE bool init(double start, double end) noexcept {
+    start_t = start;
+    mid_t = (start + end) * 0.5;
+    end_t = end;
+    start_set = false;
+    end_set = false;
+    opposite_tangents = false;
+    return start_t < mid_t && mid_t < end_t;
+  }
+
+  BL_INLINE bool init_with_start(const QuadConstruct& parent) noexcept {
+    if (!init(parent.start_t, parent.mid_t))
+      return false;
+
+    quad[0] = parent.quad[0];
+    tangent_start = parent.tangent_start;
+    start_set = true;
+    return true;
+  }
+
+  BL_INLINE bool init_with_end(const QuadConstruct& parent) noexcept {
+    if (!init(parent.mid_t, parent.end_t))
+      return false;
+
+    quad[2] = parent.quad[2];
+    tangent_end = parent.tangent_end;
+    end_set = true;
+    return true;
+  }
+};
+
+static BL_INLINE bool is_nearly_zero(double v) noexcept { return bl_abs(v) <= kStrokeJoinEpsilon; }
+
+static BL_INLINE bool is_clockwise(const BLPoint& before, const BLPoint& after) noexcept {
+  return before.x * after.y > before.y * after.x;
 }
 
-static BL_INLINE uint32_t sanity_stroke_cap(uint32_t cap) noexcept {
+static BL_INLINE AngleType dot_to_angle_type(double dot) noexcept {
+  if (dot >= 0.0)
+    return is_nearly_zero(1.0 - dot) ? AngleType::kNearlyLine : AngleType::kShallow;
+  else
+    return is_nearly_zero(1.0 + dot) ? AngleType::kNearly180 : AngleType::kSharp;
+}
+
+static BL_INLINE uint32_t sanitize_stroke_cap(uint32_t cap) noexcept {
   return cap <= BL_STROKE_CAP_MAX_VALUE ? cap : BL_STROKE_CAP_BUTT;
 }
 
-static BL_INLINE bool is_miter_join_category(uint32_t join_type) noexcept {
-  return join_type == BL_STROKE_JOIN_MITER_CLIP  ||
-         join_type == BL_STROKE_JOIN_MITER_BEVEL ||
-         join_type == BL_STROKE_JOIN_MITER_ROUND ;
+static BL_INLINE uint32_t sanitize_stroke_join(uint32_t join) noexcept {
+  return join <= BL_STROKE_JOIN_MAX_VALUE ? join : BL_STROKE_JOIN_MITER_CLIP;
 }
 
-static BL_INLINE uint32_t miter_join_to_simple_join(uint32_t join_type) {
-  if (join_type == BL_STROKE_JOIN_MITER_BEVEL)
-    return BL_STROKE_JOIN_BEVEL;
-  else if (join_type == BL_STROKE_JOIN_MITER_ROUND)
-    return BL_STROKE_JOIN_ROUND;
-  else
-    return join_type;
+static BL_INLINE bool is_round_join(uint32_t join) noexcept {
+  return join == BL_STROKE_JOIN_ROUND || join == BL_STROKE_JOIN_MITER_ROUND;
 }
 
-static BL_INLINE bool test_inner_join_intersecion(const BLPoint& a0, const BLPoint& a1, const BLPoint& b0, const BLPoint& b1, const BLPoint& join) noexcept {
-  BLPoint min = bl_max(bl_min(a0, a1), bl_min(b0, b1));
-  BLPoint max = bl_min(bl_max(a0, a1), bl_max(b0, b1));
-
-  return (join.x >= min.x) & (join.y >= min.y) &
-         (join.x <= max.x) & (join.y <= max.y) ;
+static BL_INLINE bool is_bevel_join(uint32_t join) noexcept {
+  return join == BL_STROKE_JOIN_BEVEL || join == BL_STROKE_JOIN_MITER_BEVEL;
 }
 
-static BL_INLINE void angle_arc_to(PathAppender& appender, const BLPoint& p0, const BLPoint& pa, const BLPoint& pb, const BLPoint& intersection) noexcept {
+static BL_INLINE BLPoint set_length(const BLPoint& v, double len) noexcept {
+  double v_len = Geometry::magnitude(v);
+  if (!(v_len > 0.0))
+    return BLPoint(0.0, 0.0);
+  return v * (len / v_len);
+}
+
+static BL_INLINE bool degenerate_vector(const BLPoint& v) noexcept {
+  return Geometry::magnitude_squared(v) <= kStrokeLengthEpsilonSq;
+}
+
+static BL_INLINE bool set_normal_unitnormal(const BLPoint& before, const BLPoint& after, double scale, double radius, BLPoint* normal, BLPoint* unit_normal) noexcept {
+  BLPoint tangent = (after - before) * scale;
+  double tangent_len_sq = Geometry::magnitude_squared(tangent);
+  if (!(tangent_len_sq > kStrokeLengthEpsilonSq))
+    return false;
+
+  BLPoint unit_tangent = tangent / Math::sqrt(tangent_len_sq);
+  *unit_normal = Geometry::normal(unit_tangent);
+  *normal = *unit_normal * radius;
+  return true;
+}
+
+static BL_INLINE bool set_normal_unitnormal(const BLPoint& tangent, double radius, BLPoint* normal, BLPoint* unit_normal) noexcept {
+  double tangent_len_sq = Geometry::magnitude_squared(tangent);
+  if (!(tangent_len_sq > kStrokeLengthEpsilonSq))
+    return false;
+
+  BLPoint unit_tangent = tangent / Math::sqrt(tangent_len_sq);
+  *unit_normal = Geometry::normal(unit_tangent);
+  *normal = *unit_normal * radius;
+  return true;
+}
+
+static BL_INLINE bool has_non_butt_caps(const BLStrokeOptions& options) noexcept {
+  return sanitize_stroke_cap(options.start_cap) != BL_STROKE_CAP_BUTT ||
+         sanitize_stroke_cap(options.end_cap) != BL_STROKE_CAP_BUTT;
+}
+
+static BL_INLINE bool is_zero_length_since_point(const BLPath& path, size_t start_point) noexcept {
+  size_t point_count = path.size();
+  if (point_count - start_point < 2)
+    return true;
+
+  const BLPoint* pts = path.vertex_data() + start_point;
+  const BLPoint first = pts[0];
+  for (size_t i = 1; i < point_count - start_point; i++) {
+    if (pts[i] != first)
+      return false;
+  }
+  return true;
+}
+
+static BL_INLINE double point_to_line_distance_sq(const BLPoint& pt, const BLPoint& line_start, const BLPoint& line_end) noexcept {
+  BLPoint dxy = line_end - line_start;
+  BLPoint ab0 = pt - line_start;
+
+  double numer = Geometry::dot(dxy, ab0);
+  double denom = Geometry::dot(dxy, dxy);
+  double t = numer / denom;
+
+  if (t >= 0.0 && t <= 1.0) {
+    BLPoint hit = line_start + dxy * t;
+    return Geometry::magnitude_squared(hit - pt);
+  }
+  else {
+    return Geometry::magnitude_squared(pt - line_start);
+  }
+}
+
+static BL_INLINE double point_to_tangent_line_distance_sq(const BLPoint& pt, const BLPoint& line_start, const BLPoint& tangent) noexcept {
+  BLPoint ab0 = pt - line_start;
+
+  double numer = Geometry::dot(tangent, ab0);
+  double denom = Geometry::dot(tangent, tangent);
+  double t = numer / denom;
+
+  if (t >= 0.0 && t <= 1.0) {
+    BLPoint hit = line_start + tangent * t;
+    return Geometry::magnitude_squared(hit - pt);
+  }
+  else {
+    return Geometry::magnitude_squared(pt - line_start);
+  }
+}
+
+static BL_INLINE bool points_within_dist(const BLPoint& a, const BLPoint& b, double limit) noexcept {
+  return Geometry::magnitude_squared(a - b) <= limit * limit;
+}
+
+static BL_INLINE bool quad_in_line(const BLPoint quad[3]) noexcept {
+  double pt_max = -1.0;
+  int outer1 = 0;
+  int outer2 = 1;
+
+  for (int i = 0; i < 2; i++) {
+    for (int j = i + 1; j < 3; j++) {
+      BLPoint diff = quad[j] - quad[i];
+      double test_max = bl_max(bl_abs(diff.x), bl_abs(diff.y));
+      if (pt_max < test_max) {
+        outer1 = i;
+        outer2 = j;
+        pt_max = test_max;
+      }
+    }
+  }
+
+  int mid = outer1 ^ outer2 ^ 3;
+  double line_slop = pt_max * pt_max * 0.000005;
+  return point_to_line_distance_sq(quad[mid], quad[outer1], quad[outer2]) <= line_slop;
+}
+
+static BL_INLINE bool conic_in_line(const BLPoint conic[4]) noexcept {
+  return quad_in_line(conic);
+}
+
+static BL_INLINE bool cubic_in_line(const BLPoint cubic[4]) noexcept {
+  double pt_max = -1.0;
+  int outer1 = 0;
+  int outer2 = 1;
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = i + 1; j < 4; j++) {
+      BLPoint diff = cubic[j] - cubic[i];
+      double test_max = bl_max(bl_abs(diff.x), bl_abs(diff.y));
+      if (pt_max < test_max) {
+        outer1 = i;
+        outer2 = j;
+        pt_max = test_max;
+      }
+    }
+  }
+
+  int mid1 = (1 + (2 >> outer2)) >> outer1;
+  int mid2 = outer1 ^ outer2 ^ mid1;
+  double line_slop = pt_max * pt_max * 0.00001;
+  return point_to_line_distance_sq(cubic[mid1], cubic[outer1], cubic[outer2]) <= line_slop &&
+         point_to_line_distance_sq(cubic[mid2], cubic[outer1], cubic[outer2]) <= line_slop;
+}
+
+static BL_INLINE double find_quad_max_curvature(const BLPoint quad[3]) noexcept {
+  double ax = quad[1].x - quad[0].x;
+  double ay = quad[1].y - quad[0].y;
+  double bx = quad[0].x - quad[1].x - quad[1].x + quad[2].x;
+  double by = quad[0].y - quad[1].y - quad[1].y + quad[2].y;
+
+  double numer = -(ax * bx + ay * by);
+  double denom = bx * bx + by * by;
+
+  if (denom < 0.0) {
+    numer = -numer;
+    denom = -denom;
+  }
+
+  if (numer <= 0.0)
+    return 0.0;
+
+  if (numer >= denom)
+    return 1.0;
+
+  return numer / denom;
+}
+
+static BL_INLINE size_t find_cubic_inflections(const BLPoint cubic[4], double t_values[2]) noexcept {
+  double ax = cubic[1].x - cubic[0].x;
+  double ay = cubic[1].y - cubic[0].y;
+  double bx = cubic[2].x - 2.0 * cubic[1].x + cubic[0].x;
+  double by = cubic[2].y - 2.0 * cubic[1].y + cubic[0].y;
+  double cx = cubic[3].x + 3.0 * (cubic[1].x - cubic[2].x) - cubic[0].x;
+  double cy = cubic[3].y + 3.0 * (cubic[1].y - cubic[2].y) - cubic[0].y;
+
+  return Math::quad_roots(t_values,
+    bx * cy - by * cx,
+    ax * cy - ay * cx,
+    ax * by - ay * bx,
+    Math::kAfter0,
+    Math::kBefore1);
+}
+
+static BL_INLINE void formulate_f1_dot_f2(const BLPoint cubic[4], double coeff_x[4], double coeff_y[4]) noexcept {
+  auto formulate = [](const double* src, double coeff[4]) noexcept {
+    double a = src[2] - src[0];
+    double b = src[4] - 2.0 * src[2] + src[0];
+    double c = src[6] + 3.0 * (src[2] - src[4]) - src[0];
+
+    coeff[0] = c * c;
+    coeff[1] = 3.0 * b * c;
+    coeff[2] = 2.0 * b * b + c * a;
+    coeff[3] = a * b;
+  };
+
+  formulate(&cubic[0].x, coeff_x);
+  formulate(&cubic[0].y, coeff_y);
+}
+
+static BL_INLINE size_t find_cubic_max_curvature(const BLPoint cubic[4], double t_values[3]) noexcept {
+  double coeff_x[4];
+  double coeff_y[4];
+  formulate_f1_dot_f2(cubic, coeff_x, coeff_y);
+
+  for (uint32_t i = 0; i < 4; i++)
+    coeff_x[i] += coeff_y[i];
+
+  return Math::cubic_roots(t_values, coeff_x, Math::kAfter0, Math::kBefore1);
+}
+
+static BL_INLINE double calc_cubic_precision(const BLPoint cubic[4]) noexcept {
+  return (Geometry::magnitude_squared(cubic[1] - cubic[0]) +
+          Geometry::magnitude_squared(cubic[2] - cubic[1]) +
+          Geometry::magnitude_squared(cubic[3] - cubic[2])) * 1e-8;
+}
+
+static BL_INLINE bool on_same_side(const BLPoint cubic[4], int test_index, int line_index) noexcept {
+  BLPoint origin = cubic[line_index];
+  BLPoint line = cubic[line_index + 1] - origin;
+  double crosses[2];
+
+  for (int i = 0; i < 2; i++) {
+    BLPoint test_line = cubic[test_index + i] - origin;
+    crosses[i] = Geometry::cross(line, test_line);
+  }
+
+  return crosses[0] * crosses[1] >= 0.0;
+}
+
+static BL_INLINE double find_cubic_cusp(const BLPoint cubic[4]) noexcept {
+  if (cubic[0] == cubic[1] || cubic[2] == cubic[3])
+    return -1.0;
+
+  if (on_same_side(cubic, 0, 2) || on_same_side(cubic, 2, 0))
+    return -1.0;
+
+  double max_curvature[3];
+  size_t roots = find_cubic_max_curvature(cubic, max_curvature);
+  for (size_t i = 0; i < roots; i++) {
+    double t = max_curvature[i];
+    if (!(t > 0.0 && t < 1.0))
+      continue;
+
+    BLPoint dpt = Geometry::derivative_at(Geometry::cubic_ref(cubic), t);
+    if (Geometry::magnitude_squared(dpt) < calc_cubic_precision(cubic))
+      return t;
+  }
+
+  return -1.0;
+}
+
+static BL_INLINE void angle_arc_to(PathAppender& appender, const BLPoint& pivot, const BLPoint& pa, const BLPoint& pb, const BLPoint& intersection) noexcept {
   BLPoint pm = (pa + pb) * 0.5;
 
-  double denominator = Geometry::magnitude(p0 - intersection);
-  if (!(denominator > 0.0))
-    return appender.line_to(pb);
+  double denominator = Geometry::magnitude(pivot - intersection);
+  if (!(denominator > 0.0)) {
+    appender.line_to(pb);
+    return;
+  }
 
-  double w = Math::sqrt(Geometry::magnitude(p0 - pm) / denominator);
-  if (!(w > 0.0) || !Math::is_finite(w))
-    return appender.line_to(pb);
+  double w = Math::sqrt(Geometry::magnitude(pivot - pm) / denominator);
+  if (!(w > 0.0) || !Math::is_finite(w)) {
+    appender.line_to(pb);
+    return;
+  }
 
   appender.conic_to(intersection, pb, w);
-};
+}
 
-static constexpr size_t kStrokeMaxJoinConics = 2;
+static BL_INLINE BLResult add_cap(PathAppender& out, BLPoint pivot, BLPoint p1, uint32_t cap_type) noexcept {
+  BLPoint p0 = out.vtx[-1];
+  BLPoint q = Geometry::normal(p1 - p0) * 0.5;
+
+  switch (cap_type) {
+    case BL_STROKE_CAP_BUTT:
+    default:
+      out.line_to(p1);
+      break;
+
+    case BL_STROKE_CAP_SQUARE:
+      out.line_to(p0 + q);
+      out.line_to(p1 + q);
+      out.line_to(p1);
+      break;
+
+    case BL_STROKE_CAP_ROUND:
+      out.arc_quadrant_to(p0 + q, pivot + q);
+      out.arc_quadrant_to(p1 + q, p1);
+      break;
+
+    case BL_STROKE_CAP_ROUND_REV:
+      out.line_to(p0 + q);
+      out.arc_quadrant_to(p0, pivot);
+      out.arc_quadrant_to(p1, p1 + q);
+      out.line_to(p1);
+      break;
+
+    case BL_STROKE_CAP_TRIANGLE:
+      out.line_to(pivot + q);
+      out.line_to(p1);
+      break;
+
+    case BL_STROKE_CAP_TRIANGLE_REV:
+      out.line_to(p0 + q);
+      out.line_to(pivot);
+      out.line_to(p1 + q);
+      out.line_to(p1);
+      break;
+  }
+
+  return BL_SUCCESS;
+}
 
 // bl::Path - Stroke - Implementation
 // ==================================
 
 class PathStroker {
 public:
-  enum Flags : uint32_t {
-    kFlagIsOpen   = 0x01,
-    kFlagIsClosed = 0x02
-  };
-
-  // Stroke input.
   PathIterator _iter;
-
-  // Stroke options.
   const BLStrokeOptions& _options;
   const BLApproximationOptions& _approx;
 
-  struct SideData {
-    BLPath* path;            // Output path (outer/inner, per side).
-    size_t figure_offset;     // Start of the figure offset in output path (only A path).
-    PathAppender appender; // Output path appended (outer/inner, per side).
-    double d;                // Distance (StrokeWidth / 2).
-    double d2;               // Distance multiplied by 2.
-  };
+  BLPath* _a_path;
+  BLPath* _b_path;
+  BLPath* _c_path;
+  BLPath _cusp_path;
 
-  double _miter_limit;        // Miter limit possibly clamped to a safe range.
-  double _miter_limit_sq;      // Miter limit squared.
-  uint32_t _join_type;        // Simplified join type.
-  SideData _side_data[2];     // A and B data (outer/inner side).
+  PathAppender _a_out;
+  PathAppender _b_out;
 
-  // Stroke output.
-  BLPath* _cPath;            // Output C path.
+  double _radius;
+  double _miter_limit;
+  double _inv_miter_limit;
+  double _inv_res_scale;
+  double _inv_res_scale_sq;
 
-  // Global state.
-  BLPoint _p0;               // Current point.
-  BLPoint _n0;               // Unit normal of `_p0`.
-  BLPoint _pInitial;         // Initial point (MoveTo).
-  BLPoint _nInitial;         // Unit normal of `_pInitial`.
-  uint32_t _flags;           // Work flags.
+  BLPoint _first_normal;
+  BLPoint _prev_normal;
+  BLPoint _first_unit_normal;
+  BLPoint _prev_unit_normal;
+  BLPoint _first_pt;
+  BLPoint _prev_pt;
+  BLPoint _first_outer_pt;
+
+  size_t _a_figure_offset;
+  size_t _b_figure_offset;
+
+  int _segment_count;
+  bool _first_is_line;
+  bool _prev_is_line;
+  bool _join_completed;
+  uint32_t _recursion_depth;
+  bool _found_tangents;
+  StrokeType _stroke_type;
+  uint32_t _join_override;
 
   BL_INLINE PathStroker(const BLPathView& input, const BLStrokeOptions& options, const BLApproximationOptions& approx, BLPath* a, BLPath* b, BLPath* c) noexcept
     : _iter(input),
       _options(options),
       _approx(approx),
-      _join_type(options.join),
-      _cPath(c) {
+      _a_path(a),
+      _b_path(b),
+      _c_path(c),
+      _radius(options.width * 0.5),
+      _miter_limit(options.miter_limit),
+      _inv_miter_limit(options.miter_limit > 0.0 ? 1.0 / options.miter_limit : std::numeric_limits<double>::infinity()),
+      _inv_res_scale(4.0 * approx.simplify_tolerance),
+      _inv_res_scale_sq(Math::square(_inv_res_scale)),
+      _a_figure_offset(0),
+      _b_figure_offset(0),
+      _segment_count(-1),
+      _first_is_line(false),
+      _prev_is_line(false),
+      _join_completed(false),
+      _recursion_depth(0),
+      _found_tangents(false),
+      _stroke_type(StrokeType::kOuter),
+      _join_override(UINT32_MAX) {}
 
-    _side_data[0].path = a;
-    _side_data[0].figure_offset = 0;
-    _side_data[0].d = options.width * 0.5;
-    _side_data[0].d2 = options.width;
-    _side_data[1].path = b;
-    _side_data[1].figure_offset = 0;
-    _side_data[1].d = -_side_data[0].d;
-    _side_data[1].d2 = -_side_data[0].d2;
+  BL_INLINE bool has_only_move_to() const noexcept { return _segment_count == 0; }
+  BL_INLINE BLPoint move_to_pt() const noexcept { return _first_pt; }
 
-    // Initialize miter calculation options. What we do here is to change `_join_type` to a value that would be easier
-    // for us to use during joining. We always honor `_miter_limit_sq` even when the `_join_type` is not miter to prevent
-    // emitting very small line segments next to next other, which saves vertices and also prevents border cases in
-    // additional processing.
-    if (is_miter_join_category(_join_type)) {
-      // Simplify miter-join type to non-miter join, if possible.
-      _join_type = miter_join_to_simple_join(_join_type);
-
-      // Final miter limit is `0.5 * width * miter_limit`.
-      _miter_limit = d() * options.miter_limit;
-      _miter_limit_sq = Math::square(_miter_limit);
-    }
-    else {
-      _miter_limit = kStrokeMiterMinimum;
-      _miter_limit_sq = kStrokeMiterMinimumSq;
-    }
+  BL_INLINE bool is_current_contour_empty() const noexcept {
+    return is_zero_length_since_point(*_b_path, _b_figure_offset) &&
+           is_zero_length_since_point(*_a_path, _a_figure_offset);
   }
 
-  BL_INLINE bool is_open() const noexcept { return (_flags & kFlagIsOpen) != 0; }
-  BL_INLINE bool is_closed() const noexcept { return (_flags & kFlagIsClosed) != 0; }
-
-  BL_INLINE SideData& side_data(Side side) noexcept { return _side_data[size_t(side)]; }
-
-  BL_INLINE double d() const noexcept { return _side_data[0].d; }
-  BL_INLINE double d(Side side) const noexcept { return _side_data[size_t(side)].d; }
-
-  BL_INLINE double d2() const noexcept { return _side_data[0].d2; }
-  BL_INLINE double d2(Side side) const noexcept { return _side_data[size_t(side)].d2; }
-
-  BL_INLINE BLPath* a_path() const noexcept { return _side_data[size_t(Side::kA)].path; }
-  BL_INLINE BLPath* b_path() const noexcept { return _side_data[size_t(Side::kB)].path; }
-  BL_INLINE BLPath* c_path() const noexcept { return _cPath; }
-
-  BL_INLINE BLPath* outer_path(Side side) const noexcept { return _side_data[size_t(side)].path; }
-  BL_INLINE BLPath* inner_path(Side side) const noexcept { return _side_data[size_t(opposite_side(side))].path; }
-
-  BL_INLINE PathAppender& a_out() noexcept { return _side_data[size_t(Side::kA)].appender; }
-  BL_INLINE PathAppender& b_out() noexcept { return _side_data[size_t(Side::kB)].appender; }
-
-  BL_INLINE PathAppender& outer_appender(Side side) noexcept { return _side_data[size_t(side)].appender; }
-  BL_INLINE PathAppender& inner_appender(Side side) noexcept { return _side_data[size_t(opposite_side(side))].appender; }
-
   BL_INLINE BLResult ensure_appenders_capacity(size_t a_required, size_t b_required, size_t a_conic_required = 0, size_t b_conic_required = 0) noexcept {
-    uint32_t ok = uint32_t(a_out().remaining_size() >= a_required) &
-                  uint32_t(b_out().remaining_size() >= b_required) &
-                  uint32_t(a_out().remaining_conic_weight_size() >= a_conic_required) &
-                  uint32_t(b_out().remaining_conic_weight_size() >= b_conic_required) ;
+    uint32_t ok = uint32_t(_a_out.remaining_size() >= a_required) &
+                  uint32_t(_b_out.remaining_size() >= b_required) &
+                  uint32_t(_a_out.remaining_conic_weight_size() >= a_conic_required) &
+                  uint32_t(_b_out.remaining_conic_weight_size() >= b_conic_required);
 
     if (BL_LIKELY(ok))
       return BL_SUCCESS;
 
-    return a_out().ensure(a_path(), a_required, a_conic_required) |
-           b_out().ensure(b_path(), b_required, b_conic_required) ;
+    return _a_out.ensure(_a_path, a_required, a_conic_required) |
+           _b_out.ensure(_b_path, b_required, b_conic_required);
   }
 
-  BL_INLINE_IF_NOT_DEBUG BLResult stroke(BLPathStrokeSinkFunc sink, void* user_data) noexcept {
-    size_t figure_start_idx = 0;
-    size_t estimated_size = _iter.remaining_forward() * 2u;
+  BL_INLINE BLResult ensure_active_side_capacity(size_t required, size_t conic_required = 0) noexcept {
+    if (_stroke_type == StrokeType::kOuter)
+      return ensure_appenders_capacity(required, 0, conic_required, 0);
+    else
+      return ensure_appenders_capacity(0, required, 0, conic_required);
+  }
 
-    BL_PROPAGATE(a_path()->reserve(a_path()->size() + estimated_size));
+  BL_INLINE PathAppender& active_side() noexcept {
+    return _stroke_type == StrokeType::kOuter ? _a_out : _b_out;
+  }
+
+  BL_INLINE void set_last_point(PathAppender& out, const BLPoint& p) noexcept {
+    out.vtx[-1] = p;
+  }
+
+  BL_INLINE uint32_t current_join() const noexcept {
+    return _join_override <= BL_STROKE_JOIN_MAX_VALUE ? _join_override : sanitize_stroke_join(_options.join);
+  }
+
+  BL_INLINE void move_to(const BLPoint& pt) noexcept {
+    _segment_count = 0;
+    _first_pt = pt;
+    _prev_pt = pt;
+    _first_is_line = false;
+    _join_completed = false;
+    _prev_is_line = false;
+  }
+
+  BL_INLINE bool has_valid_tangent(PathIterator iter) const noexcept {
+    while (!iter.at_end()) {
+      uint8_t cmd = iter.cmd[0];
+      if (cmd == BL_PATH_CMD_MOVE)
+        return false;
+
+      if (cmd == BL_PATH_CMD_ON) {
+        if (iter.vtx[0] != _prev_pt)
+          return true;
+        iter++;
+        continue;
+      }
+
+      if (cmd == BL_PATH_CMD_QUAD || cmd == BL_PATH_CMD_CONIC) {
+        if (iter.remaining_forward() < 2)
+          return false;
+        if (!(iter.vtx[0] == _prev_pt && iter.vtx[1] == _prev_pt))
+          return true;
+        iter += 2;
+        continue;
+      }
+
+      if (cmd == BL_PATH_CMD_CUBIC) {
+        if (iter.remaining_forward() < 3)
+          return false;
+        if (!(iter.vtx[0] == _prev_pt && iter.vtx[1] == _prev_pt && iter.vtx[2] == _prev_pt))
+          return true;
+        iter += 3;
+        continue;
+      }
+
+      return false;
+    }
+
+    return false;
+  }
+
+  BL_INLINE bool pre_join_to(const BLPoint& curr_pt, BLPoint* normal, BLPoint* unit_normal, bool curr_is_line) noexcept {
+    if (!set_normal_unitnormal(_prev_pt, curr_pt, 1.0, _radius, normal, unit_normal)) {
+      if (_segment_count != 0 || !has_non_butt_caps(_options))
+        return false;
+
+      normal->reset(_radius, 0.0);
+      unit_normal->reset(1.0, 0.0);
+    }
+
+    if (_segment_count == 0) {
+      _first_is_line = curr_is_line;
+      _first_normal = *normal;
+      _first_unit_normal = *unit_normal;
+      _first_outer_pt = _prev_pt + *normal;
+
+      _a_out.move_to(_first_outer_pt);
+      _b_out.move_to(_prev_pt - *normal);
+    }
+    else {
+      join_to(_prev_unit_normal, _prev_pt, *unit_normal, _prev_is_line, curr_is_line);
+    }
+
+    _prev_is_line = curr_is_line;
+    return true;
+  }
+
+  BL_INLINE void post_join_to(const BLPoint& curr_pt, const BLPoint& normal, const BLPoint& unit_normal) noexcept {
+    _join_completed = true;
+    _prev_pt = curr_pt;
+    _prev_normal = normal;
+    _prev_unit_normal = unit_normal;
+    _segment_count++;
+  }
+
+  BL_INLINE void line_to_current_segment_end(const BLPoint& curr_pt, const BLPoint& normal) noexcept {
+    _a_out.line_to(curr_pt + normal);
+    _b_out.line_to(curr_pt - normal);
+  }
+
+  BL_INLINE void handle_inner_join(PathAppender& inner, const BLPoint& pivot, const BLPoint& after) noexcept {
+    inner.line_to(pivot);
+    inner.line_to(pivot - after);
+  }
+
+  struct JoinSideSelection {
+    PathAppender* outer;
+    PathAppender* inner;
+    BLPoint before;
+    BLPoint after;
+    BLPoint before_tangent;
+    BLPoint after_tangent;
+  };
+
+  BL_INLINE JoinSideSelection select_join_sides(PathAppender& a_ref, PathAppender& b_ref, const BLPoint& pivot, const BLPoint& before_unit, const BLPoint& after_unit) noexcept {
+    JoinSideSelection selection {
+      &a_ref,
+      &b_ref,
+      before_unit,
+      after_unit,
+      BLPoint(before_unit.y, -before_unit.x),
+      BLPoint(after_unit.y, -after_unit.x)
+    };
+    double outer_sign = is_clockwise(before_unit, after_unit) ? -1.0 : 1.0;
+    double a_sign = Geometry::dot(a_ref.vtx[-1] - pivot, before_unit) < 0.0 ? -1.0 : 1.0;
+
+    if (a_sign != outer_sign) {
+      using std::swap;
+      swap(selection.outer, selection.inner);
+    }
+
+    selection.before *= outer_sign;
+    selection.after *= outer_sign;
+    return selection;
+  }
+
+  BL_INLINE void blunt_join(PathAppender& outer, PathAppender& inner, const BLPoint&, const BLPoint& pivot, const BLPoint& after_unit) noexcept {
+    BLPoint after = after_unit * _radius;
+    outer.line_to(pivot + after);
+    handle_inner_join(inner, pivot, after);
+  }
+
+  BL_INLINE void round_join(PathAppender& outer, PathAppender& inner, const BLPoint& before_unit, const BLPoint& pivot, const BLPoint& after_unit) noexcept {
+    double dot_prod = Geometry::dot(before_unit, after_unit);
+    if (dot_to_angle_type(dot_prod) == AngleType::kNearlyLine)
+      return;
+
+    BLPoint pa = outer.vtx[-1];
+    BLPoint pb = pivot + after_unit * _radius;
+
+    if (Geometry::dot(pivot - pa, pivot - pb) < 0.0) {
+      BLPoint n2 = Geometry::normal(Geometry::unit_vector(pb - pa));
+      if (Math::is_finite(n2.x)) {
+        BLPoint incoming = pa - outer.vtx[-2];
+        if (!degenerate_vector(incoming) && Geometry::dot(pivot + n2 * _radius - pa, incoming) < 0.0)
+          n2 = -n2;
+
+        BLPoint m = before_unit + n2;
+        BLPoint k = m * (_radius + _radius) / Geometry::magnitude_squared(m);
+        BLPoint q = n2 * _radius;
+
+        BLPoint pc1 = pivot + k;
+        BLPoint pp1 = pivot + q;
+        BLPoint pc2 = Math::lerp(pc1, pp1, 2.0);
+
+        angle_arc_to(outer, pivot, pa, pp1, pc1);
+        angle_arc_to(outer, pivot, pp1, pb, pc2);
+      }
+      else {
+        outer.line_to(pb);
+      }
+    }
+    else {
+      BLPoint m = before_unit + after_unit;
+      BLPoint k = m * (_radius + _radius) / Geometry::magnitude_squared(m);
+      angle_arc_to(outer, pivot, pa, pb, pivot + k);
+    }
+
+    handle_inner_join(inner, pivot, after_unit * _radius);
+  }
+
+  BL_INLINE void miter_clip_join(PathAppender& outer, PathAppender& inner, const BLPoint& before_unit, const BLPoint& pivot, const BLPoint& after_unit, const BLPoint& before_tangent, const BLPoint& after_tangent, bool prev_is_line) noexcept {
+    BLPoint m = before_unit + after_unit;
+    BLPoint k = m * (_radius + _radius) / Geometry::magnitude_squared(m);
+    BLPoint after = after_unit * _radius;
+
+    if (Geometry::magnitude_squared(k) <= Math::square(_radius * _miter_limit)) {
+      BLPoint mid = pivot + k;
+      if (prev_is_line)
+        set_last_point(outer, mid);
+      else
+        outer.line_to(mid);
+      outer.line_to(pivot + after);
+      handle_inner_join(inner, pivot, after);
+      return;
+    }
+
+    double b2 = bl_abs(Geometry::cross(k, before_unit));
+    if (b2 > 0.0)
+      b2 = b2 * (_radius * _miter_limit) / Geometry::magnitude(k);
+    else
+      b2 = _radius * _miter_limit;
+
+    BLPoint t0 = pivot + _radius * before_unit + b2 * before_tangent;
+    BLPoint t1 = pivot + after - b2 * after_tangent;
+
+    if (prev_is_line)
+      set_last_point(outer, t0);
+    else
+      outer.line_to(t0);
+
+    outer.line_to(t1);
+    outer.line_to(pivot + after);
+    handle_inner_join(inner, pivot, after);
+  }
+
+  BL_INLINE void miter_join(PathAppender& outer, PathAppender& inner, const BLPoint& before_unit, const BLPoint& pivot, const BLPoint& after_unit, const BLPoint& before_tangent, const BLPoint& after_tangent, bool prev_is_line, bool curr_is_line, uint32_t join_type) noexcept {
+    double dot_prod = Geometry::dot(before_unit, after_unit);
+    AngleType angle_type = dot_to_angle_type(dot_prod);
+
+    if (angle_type == AngleType::kNearlyLine)
+      return;
+
+    if (join_type == BL_STROKE_JOIN_MITER_CLIP) {
+      miter_clip_join(outer, inner, before_unit, pivot, after_unit, before_tangent, after_tangent, prev_is_line);
+      return;
+    }
+
+    if (angle_type == AngleType::kNearly180) {
+      blunt_join(outer, inner, before_unit, pivot, after_unit);
+      return;
+    }
+
+    double sin_half_angle = Math::sqrt(0.5 * (1.0 + dot_prod));
+    if (!(dot_prod == 0.0 && _inv_miter_limit <= kStrokeOneOverSqrt2) && sin_half_angle < _inv_miter_limit) {
+      if (join_type == BL_STROKE_JOIN_MITER_ROUND)
+        round_join(outer, inner, before_unit, pivot, after_unit);
+      else
+        blunt_join(outer, inner, before_unit, pivot, after_unit);
+      return;
+    }
+
+    BLPoint mid = before_unit + after_unit;
+    double mid_scale = (_radius + _radius) / Geometry::magnitude_squared(mid);
+    if (!Math::is_finite(mid_scale)) {
+      blunt_join(outer, inner, before_unit, pivot, after_unit);
+      return;
+    }
+
+    mid *= mid_scale;
+
+    if (prev_is_line)
+      set_last_point(outer, pivot + mid);
+    else
+      outer.line_to(pivot + mid);
+
+    BLPoint after_scaled = after_unit * _radius;
+    if (!curr_is_line)
+      outer.line_to(pivot + after_scaled);
+
+    handle_inner_join(inner, pivot, after_scaled);
+  }
+
+  BL_INLINE void emit_join(const JoinSideSelection& selection, const BLPoint& pivot, bool prev_is_line, bool curr_is_line) noexcept {
+    uint32_t join = current_join();
+
+    if (join == BL_STROKE_JOIN_ROUND || join == BL_STROKE_JOIN_BEVEL)
+      prev_is_line = false;
+
+    if (join == BL_STROKE_JOIN_ROUND)
+      round_join(*selection.outer, *selection.inner, selection.before, pivot, selection.after);
+    else if (join == BL_STROKE_JOIN_BEVEL)
+      blunt_join(*selection.outer, *selection.inner, selection.before, pivot, selection.after);
+    else
+      miter_join(*selection.outer, *selection.inner, selection.before, pivot, selection.after, selection.before_tangent, selection.after_tangent, prev_is_line, curr_is_line, join);
+  }
+
+  BL_INLINE void join_to(const BLPoint& before_unit_normal, const BLPoint& pivot, const BLPoint& after_unit_normal, bool prev_is_line, bool curr_is_line) noexcept {
+    if (before_unit_normal == after_unit_normal)
+      return;
+
+    JoinSideSelection selection = select_join_sides(_a_out, _b_out, pivot, before_unit_normal, after_unit_normal);
+    emit_join(selection, pivot, prev_is_line, curr_is_line);
+  }
+
+  BL_INLINE void line_to_selected_segment_end(const JoinSideSelection& selection, const BLPoint& curr_pt) noexcept {
+    selection.outer->line_to(curr_pt + selection.after * _radius);
+    selection.inner->line_to(curr_pt - selection.after * _radius);
+  }
+
+  BL_INLINE BLResult line_to(const BLPoint& curr_pt, const PathIterator* iter = nullptr) noexcept {
+    double tolerance = kStrokeLengthEpsilon * bl_max(_inv_res_scale, 1.0);
+    bool teeny_line = Geometry::magnitude_squared(curr_pt - _prev_pt) <= tolerance * tolerance;
+
+    if (!has_non_butt_caps(_options) && teeny_line)
+      return BL_SUCCESS;
+
+    if (teeny_line && (_join_completed || (iter && has_valid_tangent(*iter))))
+      return BL_SUCCESS;
+
+    BLPoint normal;
+    BLPoint unit_normal;
+
+    if (!pre_join_to(curr_pt, &normal, &unit_normal, true))
+      return BL_SUCCESS;
+
+    BL_PROPAGATE(ensure_appenders_capacity(1, 1));
+    line_to_current_segment_end(curr_pt, normal);
+    post_join_to(curr_pt, normal, unit_normal);
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE void init(StrokeType stroke_type, QuadConstruct* quad_pts, double start_t, double end_t) noexcept {
+    _stroke_type = stroke_type;
+    _found_tangents = false;
+    _recursion_depth = 0;
+    quad_pts->init(start_t, end_t);
+  }
+
+  BL_INLINE void set_quad_end_normal(const BLPoint quad[3], const BLPoint& normal_ab, const BLPoint& unit_ab, BLPoint* normal_bc, BLPoint* unit_bc) const noexcept {
+    if (!set_normal_unitnormal(quad[1], quad[2], 1.0, _radius, normal_bc, unit_bc)) {
+      *normal_bc = normal_ab;
+      *unit_bc = unit_ab;
+    }
+  }
+
+  BL_INLINE void set_conic_end_normal(const BLPoint conic[4], const BLPoint& normal_ab, const BLPoint& unit_ab, BLPoint* normal_bc, BLPoint* unit_bc) const noexcept {
+    BLPoint quad[3] { conic[0], conic[1], conic[3] };
+    set_quad_end_normal(quad, normal_ab, unit_ab, normal_bc, unit_bc);
+  }
+
+  BL_INLINE void set_cubic_end_normal(const BLPoint cubic[4], const BLPoint& normal_ab, const BLPoint& unit_ab, BLPoint* normal_cd, BLPoint* unit_cd) const noexcept {
+    BLPoint ab = cubic[1] - cubic[0];
+    BLPoint cd = cubic[3] - cubic[2];
+    bool degenerate_ab = degenerate_vector(ab);
+    bool degenerate_cd = degenerate_vector(cd);
+
+    if (degenerate_ab && degenerate_cd) {
+      *normal_cd = normal_ab;
+      *unit_cd = unit_ab;
+      return;
+    }
+
+    if (degenerate_ab) {
+      ab = cubic[2] - cubic[0];
+      degenerate_ab = degenerate_vector(ab);
+    }
+    if (degenerate_cd) {
+      cd = cubic[3] - cubic[1];
+      degenerate_cd = degenerate_vector(cd);
+    }
+
+    if (degenerate_ab || degenerate_cd || !set_normal_unitnormal(cd, _radius, normal_cd, unit_cd)) {
+      *normal_cd = normal_ab;
+      *unit_cd = unit_ab;
+    }
+  }
+
+  BL_INLINE void set_ray_pts(const BLPoint& t_pt, BLPoint* dxy, BLPoint* on_pt, BLPoint* tangent) const noexcept {
+    *dxy = set_length(*dxy, _radius);
+    if (dxy->x == 0.0 && dxy->y == 0.0)
+      dxy->reset(_radius, 0.0);
+
+    BLPoint offset = Geometry::normal(*dxy) * double(int(_stroke_type));
+    *on_pt = t_pt + offset;
+
+    if (tangent)
+      *tangent = *dxy;
+  }
+
+  BL_INLINE void quad_perp_ray(const BLPoint quad[3], double t, BLPoint* t_pt, BLPoint* on_pt, BLPoint* tangent) const noexcept {
+    Geometry::QuadDerivativeCoefficients dc = Geometry::derivative_coefficients_of(Geometry::quad_ref(quad));
+    BLPoint dxy = dc.a * t + dc.b;
+    *t_pt = Geometry::evaluate_precise(Geometry::quad_ref(quad), t);
+
+    if (degenerate_vector(dxy))
+      dxy = quad[2] - quad[0];
+
+    set_ray_pts(*t_pt, &dxy, on_pt, tangent);
+  }
+
+  BL_INLINE void conic_perp_ray(const BLPoint conic[4], double t, BLPoint* t_pt, BLPoint* on_pt, BLPoint* tangent) const noexcept {
+    BLPoint a, b, c;
+    Geometry::get_conic_derivative_coefficients(conic, a, b, c);
+    BLPoint dxy = (a * t + b) * t + c;
+    *t_pt = Geometry::eval_conic_precise(conic, BLPoint(t, t));
+
+    if (degenerate_vector(dxy))
+      dxy = conic[3] - conic[0];
+
+    set_ray_pts(*t_pt, &dxy, on_pt, tangent);
+  }
+
+  BL_INLINE void cubic_perp_ray(const BLPoint cubic[4], double t, BLPoint* t_pt, BLPoint* on_pt, BLPoint* tangent) const noexcept {
+    BLPoint dxy = Geometry::derivative_at(Geometry::cubic_ref(cubic), t);
+    *t_pt = Geometry::evaluate_precise(Geometry::cubic_ref(cubic), t);
+
+    if (degenerate_vector(dxy)) {
+      if (t <= kStrokeJoinEpsilon) {
+        dxy = cubic[2] - cubic[0];
+      }
+      else if (1.0 - t <= kStrokeJoinEpsilon) {
+        dxy = cubic[3] - cubic[1];
+      }
+      else {
+        BLPoint chopped[8];
+        Geometry::split(Geometry::cubic_ref(cubic), Geometry::cubic_out(chopped), Geometry::cubic_out(chopped + 4), t);
+        dxy = chopped[4] - chopped[3];
+        if (degenerate_vector(dxy))
+          dxy = chopped[4] - chopped[2];
+      }
+
+      if (degenerate_vector(dxy))
+        dxy = cubic[3] - cubic[0];
+    }
+
+    set_ray_pts(*t_pt, &dxy, on_pt, tangent);
+  }
+
+  BL_INLINE void quad_ends(const BLPoint quad[3], QuadConstruct* quad_pts) const noexcept {
+    if (!quad_pts->start_set) {
+      BLPoint quad_start_pt;
+      quad_perp_ray(quad, quad_pts->start_t, &quad_start_pt, &quad_pts->quad[0], &quad_pts->tangent_start);
+      quad_pts->start_set = true;
+    }
+
+    if (!quad_pts->end_set) {
+      BLPoint quad_end_pt;
+      quad_perp_ray(quad, quad_pts->end_t, &quad_end_pt, &quad_pts->quad[2], &quad_pts->tangent_end);
+      quad_pts->end_set = true;
+    }
+  }
+
+  BL_INLINE void conic_ends(const BLPoint conic[4], QuadConstruct* quad_pts) const noexcept {
+    if (!quad_pts->start_set) {
+      BLPoint conic_start_pt;
+      conic_perp_ray(conic, quad_pts->start_t, &conic_start_pt, &quad_pts->quad[0], &quad_pts->tangent_start);
+      quad_pts->start_set = true;
+    }
+
+    if (!quad_pts->end_set) {
+      BLPoint conic_end_pt;
+      conic_perp_ray(conic, quad_pts->end_t, &conic_end_pt, &quad_pts->quad[2], &quad_pts->tangent_end);
+      quad_pts->end_set = true;
+    }
+  }
+
+  BL_INLINE void cubic_ends(const BLPoint cubic[4], QuadConstruct* quad_pts) const noexcept {
+    if (!quad_pts->start_set) {
+      BLPoint cubic_start_pt;
+      cubic_perp_ray(cubic, quad_pts->start_t, &cubic_start_pt, &quad_pts->quad[0], &quad_pts->tangent_start);
+      quad_pts->start_set = true;
+    }
+
+    if (!quad_pts->end_set) {
+      BLPoint cubic_end_pt;
+      cubic_perp_ray(cubic, quad_pts->end_t, &cubic_end_pt, &quad_pts->quad[2], &quad_pts->tangent_end);
+      quad_pts->end_set = true;
+    }
+  }
+
+  BL_INLINE ResultType intersect_ray(QuadConstruct* quad_pts, IntersectRayType intersect_ray_type) const noexcept {
+    const BLPoint& start = quad_pts->quad[0];
+    const BLPoint& end = quad_pts->quad[2];
+    BLPoint a_len = quad_pts->tangent_start;
+    BLPoint b_len = quad_pts->tangent_end;
+
+    double denom = Geometry::cross(a_len, b_len);
+    if (denom == 0.0 || !Math::is_finite(denom)) {
+      quad_pts->opposite_tangents = Geometry::dot(a_len, b_len) < 0.0;
+      return ResultType::kDegenerate;
+    }
+
+    quad_pts->opposite_tangents = false;
+    BLPoint ab0 = start - end;
+    double numer_a = Geometry::cross(b_len, ab0);
+    double numer_b = Geometry::cross(a_len, ab0);
+
+    if ((numer_a >= 0.0) == (numer_b >= 0.0)) {
+      double dist1 = point_to_tangent_line_distance_sq(start, end, quad_pts->tangent_end);
+      double dist2 = point_to_tangent_line_distance_sq(end, start, quad_pts->tangent_start);
+      if (bl_max(dist1, dist2) <= _inv_res_scale_sq)
+        return ResultType::kDegenerate;
+      return ResultType::kSplit;
+    }
+
+    numer_a /= denom;
+    if (numer_a > numer_a - 1.0) {
+      if (intersect_ray_type == IntersectRayType::kCtrlPt)
+        quad_pts->quad[1] = start + quad_pts->tangent_start * numer_a;
+      return ResultType::kQuad;
+    }
+
+    quad_pts->opposite_tangents = Geometry::dot(a_len, b_len) < 0.0;
+    return ResultType::kDegenerate;
+  }
+
+  static BL_INLINE int intersect_quad_ray(const BLPoint line[2], const BLPoint quad[3], double roots[2]) noexcept {
+    BLPoint vec = line[1] - line[0];
+    double r[3];
+
+    for (uint32_t i = 0; i < 3; i++)
+      r[i] = Geometry::cross(vec, quad[i] - line[0]);
+
+    double a = r[2] + r[0] - 2.0 * r[1];
+    double b = r[1] - r[0];
+    double c = r[0];
+
+    return int(Math::quad_roots(roots, a, 2.0 * b, c, 0.0, 1.0));
+  }
+
+  BL_INLINE bool point_in_quad_bounds(const BLPoint quad[3], const BLPoint& pt) const noexcept {
+    double x_min = bl_min(bl_min(quad[0].x, quad[1].x), quad[2].x);
+    double x_max = bl_max(bl_max(quad[0].x, quad[1].x), quad[2].x);
+    double y_min = bl_min(bl_min(quad[0].y, quad[1].y), quad[2].y);
+    double y_max = bl_max(bl_max(quad[0].y, quad[1].y), quad[2].y);
+
+    return pt.x + _inv_res_scale >= x_min &&
+           pt.x - _inv_res_scale <= x_max &&
+           pt.y + _inv_res_scale >= y_min &&
+           pt.y - _inv_res_scale <= y_max;
+  }
+
+  static BL_INLINE bool sharp_angle(const BLPoint quad[3]) noexcept {
+    BLPoint smaller = quad[1] - quad[0];
+    BLPoint larger = quad[1] - quad[2];
+    double smaller_len = Geometry::magnitude_squared(smaller);
+    double larger_len = Geometry::magnitude_squared(larger);
+
+    if (smaller_len > larger_len) {
+      using std::swap;
+      swap(smaller, larger);
+      larger_len = smaller_len;
+    }
+
+    smaller = set_length(smaller, larger_len);
+    if (smaller.x == 0.0 && smaller.y == 0.0)
+      return false;
+
+    return Geometry::dot(smaller, larger) > 0.0;
+  }
+
+  BL_INLINE ResultType stroke_close_enough(const BLPoint stroke[3], const BLPoint ray[2], QuadConstruct* quad_pts) const noexcept {
+    BLPoint stroke_mid = Geometry::evaluate_precise(Geometry::quad_ref(stroke), 0.5);
+    if (points_within_dist(ray[0], stroke_mid, _inv_res_scale)) {
+      if (sharp_angle(quad_pts->quad))
+        return ResultType::kSplit;
+      return ResultType::kQuad;
+    }
+
+    if (!point_in_quad_bounds(stroke, ray[0]))
+      return ResultType::kSplit;
+
+    double roots[2];
+    if (intersect_quad_ray(ray, stroke, roots) != 1)
+      return ResultType::kSplit;
+
+    BLPoint quad_pt = Geometry::evaluate_precise(Geometry::quad_ref(stroke), roots[0]);
+    double error = _inv_res_scale * (1.0 - bl_abs(roots[0] - 0.5) * 2.0);
+    if (points_within_dist(ray[0], quad_pt, error)) {
+      if (sharp_angle(quad_pts->quad))
+        return ResultType::kSplit;
+      return ResultType::kQuad;
+    }
+
+    return ResultType::kSplit;
+  }
+
+  BL_INLINE ResultType compare_quad_quad(const BLPoint quad[3], QuadConstruct* quad_pts) const noexcept {
+    quad_ends(quad, quad_pts);
+
+    ResultType result_type = intersect_ray(quad_pts, IntersectRayType::kCtrlPt);
+    if (result_type != ResultType::kQuad)
+      return result_type;
+
+    BLPoint ray[2];
+    quad_perp_ray(quad, quad_pts->mid_t, &ray[1], &ray[0], nullptr);
+    return stroke_close_enough(quad_pts->quad, ray, quad_pts);
+  }
+
+  BL_INLINE ResultType compare_quad_conic(const BLPoint conic[4], QuadConstruct* quad_pts) const noexcept {
+    conic_ends(conic, quad_pts);
+
+    ResultType result_type = intersect_ray(quad_pts, IntersectRayType::kCtrlPt);
+    if (result_type != ResultType::kQuad)
+      return result_type;
+
+    BLPoint ray[2];
+    conic_perp_ray(conic, quad_pts->mid_t, &ray[1], &ray[0], nullptr);
+    return stroke_close_enough(quad_pts->quad, ray, quad_pts);
+  }
+
+  BL_INLINE ResultType tangents_meet(const BLPoint cubic[4], QuadConstruct* quad_pts) noexcept {
+    cubic_ends(cubic, quad_pts);
+    return intersect_ray(quad_pts, IntersectRayType::kResultType);
+  }
+
+  BL_INLINE BLResult add_degenerate_line(const QuadConstruct* quad_pts) noexcept {
+    BL_PROPAGATE(ensure_active_side_capacity(1));
+    active_side().line_to(quad_pts->quad[2]);
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE void cubic_quad_mid(const BLPoint cubic[4], const QuadConstruct* quad_pts, BLPoint* mid) const noexcept {
+    BLPoint cubic_mid_pt;
+    cubic_perp_ray(cubic, quad_pts->mid_t, &cubic_mid_pt, mid, nullptr);
+  }
+
+  BL_INLINE bool cubic_mid_on_line(const BLPoint cubic[4], const QuadConstruct* quad_pts) const noexcept {
+    BLPoint stroke_mid;
+    cubic_quad_mid(cubic, quad_pts, &stroke_mid);
+    double dist = point_to_line_distance_sq(stroke_mid, quad_pts->quad[0], quad_pts->quad[2]);
+    return dist < _inv_res_scale_sq;
+  }
+
+  BL_INLINE ResultType compare_quad_cubic(const BLPoint cubic[4], QuadConstruct* quad_pts) const noexcept {
+    cubic_ends(cubic, quad_pts);
+
+    ResultType result_type = intersect_ray(quad_pts, IntersectRayType::kCtrlPt);
+    if (result_type != ResultType::kQuad)
+      return result_type;
+
+    BLPoint ray[2];
+    cubic_perp_ray(cubic, quad_pts->mid_t, &ray[1], &ray[0], nullptr);
+    return stroke_close_enough(quad_pts->quad, ray, quad_pts);
+  }
+
+  BL_INLINE BLResult quad_stroke(const BLPoint quad[3], QuadConstruct* quad_pts) noexcept {
+    ResultType result_type = compare_quad_quad(quad, quad_pts);
+    if (result_type == ResultType::kQuad) {
+      BL_PROPAGATE(ensure_active_side_capacity(2, 0));
+      active_side().quad_to(quad_pts->quad[1], quad_pts->quad[2]);
+      return BL_SUCCESS;
+    }
+
+    if (result_type == ResultType::kDegenerate)
+      return add_degenerate_line(quad_pts);
+
+    if (++_recursion_depth > kStrokeQuadRecursiveLimit)
+      return add_degenerate_line(quad_pts);
+
+    QuadConstruct half;
+    if (!half.init_with_start(*quad_pts))
+      return add_degenerate_line(quad_pts);
+    BL_PROPAGATE(quad_stroke(quad, &half));
+
+    if (!half.init_with_end(*quad_pts))
+      return add_degenerate_line(quad_pts);
+    BL_PROPAGATE(quad_stroke(quad, &half));
+
+    _recursion_depth--;
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE BLResult conic_stroke(const BLPoint conic[4], QuadConstruct* quad_pts) noexcept {
+    ResultType result_type = compare_quad_conic(conic, quad_pts);
+    if (result_type == ResultType::kQuad) {
+      BL_PROPAGATE(ensure_active_side_capacity(2));
+      active_side().quad_to(quad_pts->quad[1], quad_pts->quad[2]);
+      return BL_SUCCESS;
+    }
+
+    if (result_type == ResultType::kDegenerate)
+      return add_degenerate_line(quad_pts);
+
+    if (++_recursion_depth > kStrokeConicRecursiveLimit)
+      return add_degenerate_line(quad_pts);
+
+    QuadConstruct half;
+    if (!half.init_with_start(*quad_pts))
+      return add_degenerate_line(quad_pts);
+    BL_PROPAGATE(conic_stroke(conic, &half));
+
+    if (!half.init_with_end(*quad_pts))
+      return add_degenerate_line(quad_pts);
+    BL_PROPAGATE(conic_stroke(conic, &half));
+
+    _recursion_depth--;
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE BLResult cubic_stroke(const BLPoint cubic[4], QuadConstruct* quad_pts) noexcept {
+    if (!_found_tangents) {
+      ResultType result_type = tangents_meet(cubic, quad_pts);
+      if (result_type != ResultType::kQuad) {
+        if ((result_type == ResultType::kDegenerate || points_within_dist(quad_pts->quad[0], quad_pts->quad[2], _inv_res_scale)) &&
+            cubic_mid_on_line(cubic, quad_pts)) {
+          return add_degenerate_line(quad_pts);
+        }
+      }
+      else {
+        _found_tangents = true;
+      }
+    }
+
+    if (_found_tangents) {
+      ResultType result_type = compare_quad_cubic(cubic, quad_pts);
+      if (result_type == ResultType::kQuad) {
+        BL_PROPAGATE(ensure_active_side_capacity(2));
+        active_side().quad_to(quad_pts->quad[1], quad_pts->quad[2]);
+        return BL_SUCCESS;
+      }
+
+      if (result_type == ResultType::kDegenerate && !quad_pts->opposite_tangents)
+        return add_degenerate_line(quad_pts);
+    }
+
+    if (!Math::is_finite(quad_pts->quad[2].x) || !Math::is_finite(quad_pts->quad[2].y))
+      return BL_SUCCESS;
+
+    if (++_recursion_depth > (_found_tangents ? kStrokeCubicRecursiveLimit : kStrokeTangentRecursiveLimit))
+      return add_degenerate_line(quad_pts);
+
+    QuadConstruct half;
+    if (!half.init_with_start(*quad_pts))
+      return add_degenerate_line(quad_pts);
+    BL_PROPAGATE(cubic_stroke(cubic, &half));
+
+    if (!half.init_with_end(*quad_pts))
+      return add_degenerate_line(quad_pts);
+    BL_PROPAGATE(cubic_stroke(cubic, &half));
+
+    _recursion_depth--;
+    return BL_SUCCESS;
+  }
+
+  static BL_INLINE ReductionType check_quad_linear(const BLPoint quad[3], BLPoint* reduction) noexcept {
+    bool degenerate_ab = degenerate_vector(quad[1] - quad[0]);
+    bool degenerate_bc = degenerate_vector(quad[2] - quad[1]);
+
+    if (degenerate_ab && degenerate_bc)
+      return ReductionType::kPoint;
+
+    if (degenerate_ab || degenerate_bc)
+      return ReductionType::kLine;
+
+    if (!quad_in_line(quad))
+      return ReductionType::kQuad;
+
+    double t = find_quad_max_curvature(quad);
+    if (t == 0.0 || t == 1.0 || !Math::is_finite(t))
+      return ReductionType::kLine;
+
+    *reduction = Geometry::evaluate_precise(Geometry::quad_ref(quad), t);
+    return ReductionType::kDegenerate;
+  }
+
+  static BL_INLINE ReductionType check_conic_linear(const BLPoint conic[4], BLPoint* reduction) noexcept {
+    bool degenerate_ab = degenerate_vector(conic[1] - conic[0]);
+    bool degenerate_bc = degenerate_vector(conic[3] - conic[1]);
+
+    if (degenerate_ab && degenerate_bc)
+      return ReductionType::kPoint;
+
+    if (degenerate_ab || degenerate_bc)
+      return ReductionType::kLine;
+
+    if (!conic_in_line(conic))
+      return ReductionType::kQuad;
+
+    double t = find_quad_max_curvature(conic);
+    if (t == 0.0 || !Math::is_finite(t))
+      return ReductionType::kLine;
+
+    *reduction = Geometry::eval_conic_precise(conic, BLPoint(t, t));
+    return ReductionType::kDegenerate;
+  }
+
+  static BL_INLINE ReductionType check_cubic_linear(const BLPoint cubic[4], BLPoint reduction[3], const BLPoint** tangent_pt_ptr) noexcept {
+    bool degenerate_ab = degenerate_vector(cubic[1] - cubic[0]);
+    bool degenerate_bc = degenerate_vector(cubic[2] - cubic[1]);
+    bool degenerate_cd = degenerate_vector(cubic[3] - cubic[2]);
+
+    if (degenerate_ab && degenerate_bc && degenerate_cd)
+      return ReductionType::kPoint;
+
+    if (uint32_t(degenerate_ab) + uint32_t(degenerate_bc) + uint32_t(degenerate_cd) == 2u)
+      return ReductionType::kLine;
+
+    if (!cubic_in_line(cubic)) {
+      *tangent_pt_ptr = degenerate_ab ? &cubic[2] : &cubic[1];
+      return ReductionType::kQuad;
+    }
+
+    double t_values[3];
+    size_t count = find_cubic_max_curvature(cubic, t_values);
+    size_t reduction_count = 0;
+
+    for (size_t i = 0; i < count; i++) {
+      double t = t_values[i];
+      if (!(t > 0.0 && t < 1.0))
+        continue;
+
+      reduction[reduction_count] = Geometry::evaluate_precise(Geometry::cubic_ref(cubic), t);
+      if (reduction[reduction_count] != cubic[0] && reduction[reduction_count] != cubic[3])
+        reduction_count++;
+    }
+
+    if (reduction_count == 0)
+      return ReductionType::kLine;
+    if (reduction_count == 1)
+      return ReductionType::kDegenerate;
+    if (reduction_count == 2)
+      return ReductionType::kDegenerate2;
+    return ReductionType::kDegenerate3;
+  }
+
+  BL_INLINE BLResult append_cusp_circle(const BLPoint& center) noexcept {
+    PathAppender cusp_out;
+    BL_PROPAGATE(cusp_out.begin_append(&_cusp_path, kStrokeCircleVertices, kStrokeCircleConics));
+
+    BLPoint p0(center.x + _radius, center.y);
+    BLPoint p1(center.x, center.y + _radius);
+    BLPoint p2(center.x - _radius, center.y);
+    BLPoint p3(center.x, center.y - _radius);
+
+    cusp_out.move_to(p0);
+    cusp_out.arc_quadrant_to(BLPoint(center.x + _radius, center.y + _radius), p1);
+    cusp_out.arc_quadrant_to(BLPoint(center.x - _radius, center.y + _radius), p2);
+    cusp_out.arc_quadrant_to(BLPoint(center.x - _radius, center.y - _radius), p3);
+    cusp_out.arc_quadrant_to(BLPoint(center.x + _radius, center.y - _radius), p0);
+    cusp_out.close();
+    cusp_out.done(&_cusp_path);
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE BLResult quad_to(const BLPoint& pt1, const BLPoint& pt2) noexcept {
+    BLPoint quad[3] { _prev_pt, pt1, pt2 };
+    BLPoint reduction;
+
+    ReductionType reduction_type = check_quad_linear(quad, &reduction);
+    if (reduction_type == ReductionType::kPoint || reduction_type == ReductionType::kLine)
+      return line_to(pt2);
+
+    if (reduction_type == ReductionType::kDegenerate) {
+      BL_PROPAGATE(line_to(reduction));
+      _join_override = BL_STROKE_JOIN_ROUND;
+      BLResult result = line_to(pt2);
+      _join_override = UINT32_MAX;
+      return result;
+    }
+
+    BLPoint normal_ab;
+    BLPoint unit_ab;
+    BLPoint normal_bc;
+    BLPoint unit_bc;
+
+    if (!pre_join_to(pt1, &normal_ab, &unit_ab, false))
+      return line_to(pt2);
+
+    QuadConstruct quad_pts;
+    init(StrokeType::kOuter, &quad_pts, 0.0, 1.0);
+    BL_PROPAGATE(quad_stroke(quad, &quad_pts));
+
+    init(StrokeType::kInner, &quad_pts, 0.0, 1.0);
+    BL_PROPAGATE(quad_stroke(quad, &quad_pts));
+
+    set_quad_end_normal(quad, normal_ab, unit_ab, &normal_bc, &unit_bc);
+
+    post_join_to(pt2, normal_bc, unit_bc);
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE BLResult conic_to(const BLPoint& pt1, const BLPoint& pt2, double weight) noexcept {
+    BLPoint conic[4];
+    conic[0] = _prev_pt;
+    conic[1] = pt1;
+    conic[2].reset(weight, Math::nan<double>());
+    conic[3] = pt2;
+
+    BLPoint reduction;
+    ReductionType reduction_type = check_conic_linear(conic, &reduction);
+    if (reduction_type == ReductionType::kPoint || reduction_type == ReductionType::kLine)
+      return line_to(pt2);
+
+    if (reduction_type == ReductionType::kDegenerate) {
+      BL_PROPAGATE(line_to(reduction));
+      _join_override = BL_STROKE_JOIN_ROUND;
+      BLResult result = line_to(pt2);
+      _join_override = UINT32_MAX;
+      return result;
+    }
+
+    BLPoint normal_ab;
+    BLPoint unit_ab;
+    BLPoint normal_bc;
+    BLPoint unit_bc;
+
+    if (!pre_join_to(pt1, &normal_ab, &unit_ab, false))
+      return line_to(pt2);
+
+    QuadConstruct quad_pts;
+    init(StrokeType::kOuter, &quad_pts, 0.0, 1.0);
+    BL_PROPAGATE(conic_stroke(conic, &quad_pts));
+
+    init(StrokeType::kInner, &quad_pts, 0.0, 1.0);
+    BL_PROPAGATE(conic_stroke(conic, &quad_pts));
+
+    set_conic_end_normal(conic, normal_ab, unit_ab, &normal_bc, &unit_bc);
+
+    post_join_to(pt2, normal_bc, unit_bc);
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE BLResult cubic_to(const BLPoint& pt1, const BLPoint& pt2, const BLPoint& pt3) noexcept {
+    BLPoint cubic[4] { _prev_pt, pt1, pt2, pt3 };
+    BLPoint reduction[3];
+    const BLPoint* tangent_pt = nullptr;
+
+    ReductionType reduction_type = check_cubic_linear(cubic, reduction, &tangent_pt);
+    if (reduction_type == ReductionType::kPoint || reduction_type == ReductionType::kLine)
+      return line_to(pt3);
+
+    if (reduction_type == ReductionType::kDegenerate ||
+        reduction_type == ReductionType::kDegenerate2 ||
+        reduction_type == ReductionType::kDegenerate3) {
+      BL_PROPAGATE(line_to(reduction[0]));
+      _join_override = BL_STROKE_JOIN_ROUND;
+
+      BLResult result = BL_SUCCESS;
+      if (reduction_type >= ReductionType::kDegenerate2)
+        result |= line_to(reduction[1]);
+      if (reduction_type == ReductionType::kDegenerate3)
+        result |= line_to(reduction[2]);
+      result |= line_to(pt3);
+
+      _join_override = UINT32_MAX;
+      return result;
+    }
+
+    BLPoint normal_ab;
+    BLPoint unit_ab;
+    BLPoint normal_cd;
+    BLPoint unit_cd;
+
+    if (!pre_join_to(*tangent_pt, &normal_ab, &unit_ab, false))
+      return line_to(pt3);
+
+    double t_values[2];
+    size_t count = find_cubic_inflections(cubic, t_values);
+    double last_t = 0.0;
+
+    for (size_t i = 0; i <= count; i++) {
+      double next_t = i < count ? t_values[i] : 1.0;
+      QuadConstruct quad_pts;
+
+      init(StrokeType::kOuter, &quad_pts, last_t, next_t);
+      BL_PROPAGATE(cubic_stroke(cubic, &quad_pts));
+
+      init(StrokeType::kInner, &quad_pts, last_t, next_t);
+      BL_PROPAGATE(cubic_stroke(cubic, &quad_pts));
+
+      last_t = next_t;
+    }
+
+    double cusp_t = find_cubic_cusp(cubic);
+    if (cusp_t > 0.0) {
+      BLPoint cusp_loc = Geometry::evaluate_precise(Geometry::cubic_ref(cubic), cusp_t);
+      BL_PROPAGATE(append_cusp_circle(cusp_loc));
+    }
+
+    set_cubic_end_normal(cubic, normal_ab, unit_ab, &normal_cd, &unit_cd);
+
+    post_join_to(pt3, normal_cd, unit_cd);
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE BLResult finish_contour(bool close) noexcept {
+    _c_path->clear();
+
+    if (_segment_count <= 0)
+      return BL_SUCCESS;
+
+    if (close) {
+      BLPoint close_normal;
+      BLPoint close_unit_normal;
+
+      if (set_normal_unitnormal(_prev_pt, _first_pt, 1.0, _radius, &close_normal, &close_unit_normal)) {
+        BL_PROPAGATE(ensure_appenders_capacity(2 * kStrokeMaxJoinVertices + 1,
+                                               2 * kStrokeMaxJoinVertices + 1,
+                                               2 * kStrokeMaxJoinConics,
+                                               2 * kStrokeMaxJoinConics));
+
+        JoinSideSelection close_selection = select_join_sides(_a_out, _b_out, _prev_pt, _prev_unit_normal, close_unit_normal);
+        emit_join(close_selection, _prev_pt, _prev_is_line, true);
+        line_to_selected_segment_end(close_selection, _first_pt);
+        join_to(close_unit_normal, _first_pt, _first_unit_normal, true, _first_is_line);
+      }
+      else {
+        BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices,
+                                               kStrokeMaxJoinVertices,
+                                               kStrokeMaxJoinConics,
+                                               kStrokeMaxJoinConics));
+        join_to(_prev_unit_normal, _prev_pt, _first_unit_normal, _prev_is_line, _first_is_line);
+      }
+
+      _a_out.close();
+      _b_out.close();
+      return BL_SUCCESS;
+    }
+
+    uint32_t start_cap = sanitize_stroke_cap(_options.start_cap);
+    uint32_t end_cap = sanitize_stroke_cap(_options.end_cap);
+
+    BL_PROPAGATE(_a_out.ensure(_a_path, cap_vertex_count_table[end_cap], cap_conic_count_table[end_cap]));
+    BL_PROPAGATE(add_cap(_a_out, _prev_pt, _b_out.vtx[-1], end_cap));
+
+    PathAppender c_out;
+    BL_PROPAGATE(c_out.begin(_c_path, BL_MODIFY_OP_ASSIGN_GROW, cap_vertex_count_table[start_cap] + 1, cap_conic_count_table[start_cap]));
+    c_out.move_to(_b_path->vertex_data()[_b_figure_offset]);
+    BL_PROPAGATE(add_cap(c_out, _first_pt, _a_path->vertex_data()[_a_figure_offset], start_cap));
+    c_out.done(_c_path);
+
+    return BL_SUCCESS;
+  }
+
+  BL_INLINE BLResult stroke(BLPathStrokeSinkFunc sink, void* user_data) noexcept {
+    size_t figure_start_idx = 0;
+    size_t estimated_size = _iter.remaining_forward() * 3u;
+
+    BL_PROPAGATE(_a_path->reserve(_a_path->size() + estimated_size));
 
     while (!_iter.at_end()) {
-      // Start of the figure.
       const uint8_t* figure_start_cmd = _iter.cmd;
       if (BL_UNLIKELY(_iter.cmd[0] != BL_PATH_CMD_MOVE)) {
         if (_iter.cmd[0] != BL_PATH_CMD_CLOSE)
           return bl_make_error(BL_ERROR_INVALID_GEOMETRY);
 
         _iter++;
+        figure_start_idx++;
         continue;
       }
 
-      figure_start_idx += (size_t)(_iter.cmd - figure_start_cmd);
-      figure_start_cmd = _iter.cmd;
+      _a_figure_offset = _a_path->size();
+      _b_figure_offset = 0;
+      _cusp_path.clear();
 
-      side_data(Side::kA).figure_offset = side_data(Side::kA).path->size();
-      BL_PROPAGATE(a_out().begin(a_path(), BL_MODIFY_OP_APPEND_GROW, _iter.remaining_forward()));
-      BL_PROPAGATE(b_out().begin(b_path(), BL_MODIFY_OP_ASSIGN_GROW, 48));
+      BL_PROPAGATE(_a_out.begin(_a_path, BL_MODIFY_OP_APPEND_GROW, _iter.remaining_forward() * 2u, _iter.remaining_forward()));
+      BL_PROPAGATE(_b_out.begin(_b_path, BL_MODIFY_OP_ASSIGN_GROW, _iter.remaining_forward() * 2u, _iter.remaining_forward()));
 
-      BLPoint poly_pts[16];
-      size_t poly_size;
-
-      _p0 = *_iter.vtx;
-      _pInitial = _p0;
-      _flags = 0;
-
-      // Content of the figure.
+      move_to(*_iter.vtx);
       _iter++;
+
+      bool contour_closed = false;
       while (!_iter.at_end()) {
         BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
 
-        uint8_t cmd = _iter.cmd[0]; // Next command.
-        BLPoint p1 = _iter.vtx[0];  // Next line-to or control point.
-        BLPoint v1;                 // Vector of `p1 - _p0`.
-        BLPoint n1;                 // Unit normal of `v1`.
-
+        uint8_t cmd = _iter.cmd[0];
         if (cmd == BL_PATH_CMD_ON) {
-          // Line command, collinear curve converted to line or close of the figure.
+          BLPoint p1 = _iter.vtx[0];
           _iter++;
-LineTo:
-          v1 = p1 - _p0;
-          if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
-            continue;
-
-          n1 = Geometry::normal(Geometry::unit_vector(v1));
-          if (!is_open()) {
-            BL_PROPAGATE(open_line_to(p1, n1));
-            continue;
-          }
-
-          for (;;) {
-            BL_PROPAGATE(join_line_to(p1, n1));
-
-            if (_iter.at_end())
-              break;
-
-            BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
-
-            cmd = _iter.cmd[0];
-            p1 = _iter.vtx[0];
-
-            if (cmd != BL_PATH_CMD_ON)
-              break;
-
-            _iter++;
-            v1 = p1 - _p0;
-            if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
-              break;
-
-            n1 = Geometry::normal(Geometry::unit_vector(v1));
-          }
-          continue;
-
-          // This is again to minimize inline expansion of `smooth_poly_to()`.
-SmoothPolyTo:
-          BL_PROPAGATE(smooth_poly_to(poly_pts, poly_size));
+          BL_PROPAGATE(line_to(p1, &_iter));
           continue;
         }
-        else if (cmd == BL_PATH_CMD_QUAD) {
-          // Quadratic curve segment.
+
+        if (cmd == BL_PATH_CMD_QUAD) {
+          if (_iter.remaining_forward() < 2)
+            return bl_make_error(BL_ERROR_INVALID_GEOMETRY);
+
+          BLPoint p1 = _iter.vtx[0];
+          BLPoint p2 = _iter.vtx[1];
           _iter += 2;
-          if (BL_UNLIKELY(_iter.after_end()))
-            return BL_ERROR_INVALID_GEOMETRY;
-
-          const BLPoint* quad = _iter.vtx - 3;
-          BLPoint p2 = quad[2];
-          BLPoint v2 = p2 - p1;
-
-          v1 = p1 - _p0;
-          n1 = Geometry::normal(Geometry::unit_vector(v1));
-
-          double cm = Geometry::cross(v2, v1);
-          if (bl_abs(cm) <= kStrokeCollinearityEpsilon) {
-            // All points are [almost] collinear (degenerate case).
-            double dot = Geometry::dot(-v1, v2);
-
-            // Check if control point lies outside of the start/end points.
-            if (dot > 0.0) {
-              // Rotate all points to x-axis.
-              double r1 = Geometry::dot(p1 - _p0, v1);
-              double r2 = Geometry::dot(p2 - _p0, v1);
-
-              // Parameter of the cusp if it's within (0, 1).
-              double t = r1 / (2.0 * r1 - r2);
-              if (t > 0.0 && t < 1.0) {
-                poly_pts[0] = Geometry::evaluate(Geometry::quad_ref(quad), t);
-                poly_pts[1] = p2;
-                poly_size = 2;
-                goto SmoothPolyTo;
-              }
-            }
-
-            // Collinear without cusp => straight line.
-            p1 = p2;
-            goto LineTo;
-          }
-
-          // Very small curve segment => straight line.
-          if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq || Geometry::magnitude_squared(v2) < kStrokeLengthEpsilonSq) {
-            p1 = p2;
-            goto LineTo;
-          }
-
-          if (!is_open())
-            BL_PROPAGATE(open_curve(n1));
-          else
-            BL_PROPAGATE(join_curve(n1));
-
-          BL_PROPAGATE(offset_quad(_iter.vtx - 3));
+          BL_PROPAGATE(quad_to(p1, p2));
+          continue;
         }
-        else if (cmd == BL_PATH_CMD_CONIC) {
+
+        if (cmd == BL_PATH_CMD_CONIC) {
+          if (_iter.remaining_forward() < 2)
+            return bl_make_error(BL_ERROR_INVALID_GEOMETRY);
+
+          BLPoint p1 = _iter.vtx[0];
+          BLPoint p2 = _iter.vtx[1];
           double w = _iter.conic_weight_data[0];
           _iter += 2;
-          if (BL_UNLIKELY(_iter.after_end()))
-            return BL_ERROR_INVALID_GEOMETRY;
-
-          if (w == 1.0) {
-            BLPoint quad[3];
-            BLPoint p2 = _iter.vtx[-1];
-            BLPoint v2 = p2 - _iter.vtx[-2];
-
-            quad[0] = _p0;
-            quad[1] = _iter.vtx[-2];
-            quad[2] = p2;
-
-            v1 = quad[1] - _p0;
-            n1 = Geometry::normal(Geometry::unit_vector(v1));
-
-            double cm = Geometry::cross(v2, v1);
-            if (bl_abs(cm) <= kStrokeCollinearityEpsilon) {
-              double dot = Geometry::dot(-v1, v2);
-
-              if (dot > 0.0) {
-                double r1 = Geometry::dot(quad[1] - _p0, v1);
-                double r2 = Geometry::dot(quad[2] - _p0, v1);
-
-                double t = r1 / (2.0 * r1 - r2);
-                if (t > 0.0 && t < 1.0) {
-                  poly_pts[0] = Geometry::evaluate(Geometry::quad_ref(quad), t);
-                  poly_pts[1] = p2;
-                  poly_size = 2;
-                  goto SmoothPolyTo;
-                }
-              }
-
-              p1 = p2;
-              goto LineTo;
-            }
-
-            if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq || Geometry::magnitude_squared(v2) < kStrokeLengthEpsilonSq) {
-              p1 = p2;
-              goto LineTo;
-            }
-
-            if (!is_open())
-              BL_PROPAGATE(open_curve(n1));
-            else
-              BL_PROPAGATE(join_curve(n1));
-
-            BL_PROPAGATE(offset_quad(quad));
-            continue;
-          }
-
-          BLPoint conic[4];
-          conic[0] = _p0;
-          conic[1] = _iter.vtx[-2];
-          conic[2].reset(w, Math::nan<double>());
-          conic[3] = _iter.vtx[-1];
-
-          v1 = (conic[1] - _p0) * w;
-          if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
-            v1 = conic[3] - _p0;
-
-          if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
-            continue;
-
-          n1 = Geometry::normal(Geometry::unit_vector(v1));
-
-          if (!is_open())
-            BL_PROPAGATE(open_curve(n1));
-          else
-            BL_PROPAGATE(join_curve(n1));
-
-          BL_PROPAGATE(offset_conic(conic));
-        }
-        else if (cmd == BL_PATH_CMD_CUBIC) {
-          // Cubic curve segment.
-          _iter += 3;
-          if (BL_UNLIKELY(_iter.after_end()))
-            return BL_ERROR_INVALID_GEOMETRY;
-
-          BLPoint p[7];
-
-          int cusp = 0;
-          double tCusp = 0;
-
-          p[0] = _p0;
-          p[1] = _iter.vtx[-3];
-          p[2] = _iter.vtx[-2];
-          p[3] = _iter.vtx[-1];
-
-          // Check if the curve is flat enough to be potentially degenerate.
-          if (Geometry::is_cubic_flat(Geometry::cubic_ref(p), kStrokeDegenerateFlatness)) {
-            double dot1 = Geometry::dot(p[0] - p[1], p[3] - p[1]);
-            double dot2 = Geometry::dot(p[0] - p[2], p[3] - p[2]);
-
-            if (!(dot1 < 0.0) || !(dot2 < 0.0)) {
-              // Rotate all points to x-axis.
-              const BLPoint r = Geometry::cubic_start_tangent(Geometry::cubic_ref(p));
-
-              double r1 = Geometry::dot(p[1] - p[0], r);
-              double r2 = Geometry::dot(p[2] - p[0], r);
-              double r3 = Geometry::dot(p[3] - p[0], r);
-
-              double a = 1.0 / (3.0 * r1 - 3.0 * r2 + r3);
-              double b = 2.0 * r1 - r2;
-              double s = Math::sqrt(r2 * (r2 - r1) - r1 * (r3 - r1));
-
-              // Parameters of the cusps.
-              double t1 = a * (b - s);
-              double t2 = a * (b + s);
-
-              // Offset the first and second cusps (if they exist).
-              poly_size = 0;
-              if (t1 > kStrokeCuspTThreshold && t1 < 1.0 - kStrokeCuspTThreshold)
-                poly_pts[poly_size++] = Geometry::evaluate(Geometry::cubic_ref(p), t1);
-
-              if (t2 > kStrokeCuspTThreshold && t2 < 1.0 - kStrokeCuspTThreshold)
-                poly_pts[poly_size++] = Geometry::evaluate(Geometry::cubic_ref(p), t2);
-
-              if (poly_size == 0) {
-                p1 = p[3];
-                goto LineTo;
-              }
-
-              poly_pts[poly_size++] = p[3];
-              goto SmoothPolyTo;
-            }
-            else {
-              p1 = p[3];
-              goto LineTo;
-            }
-          }
-          else {
-            double tl;
-            Geometry::get_cubic_inflection_parameter(Geometry::cubic_ref(p), tCusp, tl);
-
-            if (tl == 0.0 && tCusp > 0.0 && tCusp < 1.0) {
-              Geometry::split(Geometry::cubic_ref(p), Geometry::cubic_out(p), Geometry::cubic_out(p + 3));
-              cusp = 1;
-            }
-          }
-
-          for (;;) {
-            v1 = p[1] - _p0;
-            if (Geometry::is_zero(v1))
-              v1 = p[2] - _p0;
-            n1 = Geometry::normal(Geometry::unit_vector(v1));
-
-            if (!is_open())
-              BL_PROPAGATE(open_curve(n1));
-            else if (cusp >= 0)
-              BL_PROPAGATE(join_curve(n1));
-            else
-              BL_PROPAGATE(join_cusp(n1));
-
-            BL_PROPAGATE(offset_cubic(p));
-            if (cusp <= 0)
-              break;
-
-            BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices, kStrokeMaxJoinVertices, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
-
-            // Second part of the cubic after the cusp. We assign `-1` to `cusp` so we can call `join_cusp()` later.
-            // This is a special join that we need in this case.
-            cusp = -1;
-            p[0] = p[3];
-            p[1] = p[4];
-            p[2] = p[5];
-            p[3] = p[6];
-          }
-        }
-        else {
-          // Either invalid command or close of the figure. If the figure is already closed it means that we have
-          // already jumped to `LineTo` and we should terminate now. Otherwise we just encountered close or
-          // something else which is not part of the current figure.
-          if (is_closed())
-            break;
-
-          if (cmd != BL_PATH_CMD_CLOSE)
-            break;
-
-          // The figure is closed. We just jump to `LineTo` to minimize inlining expansion and mark the figure as
-          // closed. Next time we terminate on `is_closed()` condition above.
-          _flags |= kFlagIsClosed;
-          p1 = _pInitial;
-          goto LineTo;
-        }
-      }
-
-      // Don't emit anything if the figure has no points (and thus no direction).
-      _iter += size_t(is_closed());
-      if (!is_open()) {
-        a_out().done(a_path());
-        b_out().done(b_path());
-        continue;
-      }
-
-      if (is_closed()) {
-        // The figure is closed => the end result is two closed figures without caps. In this case only paths
-        // A and B have a content, path C will be empty and should be thus ignored by the sink.
-
-        // Allocate space for the end join and close command.
-        BL_PROPAGATE(ensure_appenders_capacity(kStrokeMaxJoinVertices + 1, kStrokeMaxJoinVertices + 1, kStrokeMaxJoinConics, kStrokeMaxJoinConics));
-
-        BL_PROPAGATE(join_end_point(_nInitial));
-        a_out().close();
-        b_out().close();
-        c_path()->clear();
-      }
-      else {
-        // The figure is open => the end result is a single figure with caps. The paths contain the following:
-        //   A - Offset of the figure and end cap.
-        //   B - Offset of the figure that MUST BE reversed.
-        //   C - Start cap (not reversed).
-        uint32_t start_cap = sanity_stroke_cap(_options.start_cap);
-        uint32_t end_cap = sanity_stroke_cap(_options.end_cap);
-
-        BL_PROPAGATE(a_out().ensure(a_path(), cap_vertex_count_table[end_cap], cap_conic_count_table[end_cap]));
-        BL_PROPAGATE(add_cap(a_out(), _p0, b_out().vtx[-1], end_cap));
-
-        PathAppender c_out;
-        BL_PROPAGATE(c_out.begin(c_path(), BL_MODIFY_OP_ASSIGN_GROW, cap_vertex_count_table[start_cap] + 1, cap_conic_count_table[start_cap]));
-        c_out.move_to(b_path()->vertex_data()[0]);
-        BL_PROPAGATE(add_cap(c_out, _pInitial, a_path()->vertex_data()[side_data(Side::kA).figure_offset], start_cap));
-        c_out.done(c_path());
-      }
-
-      a_out().done(a_path());
-      b_out().done(b_path());
-
-      // Call the path to the provided sink with resulting paths.
-      size_t figure_end_idx = figure_start_idx + (size_t)(_iter.cmd - figure_start_cmd);
-      BL_PROPAGATE(sink(a_path(), b_path(), c_path(), figure_start_idx, figure_end_idx,  user_data));
-
-      figure_start_idx = figure_end_idx;
-    }
-
-    return BL_SUCCESS;
-  }
-
-  // Opens a new figure with a line segment starting from the current point and ending at `p1`. The `n1` is a
-  // normal calculated from a unit vector of `p1 - _p0`.
-  //
-  // This function can only be called after we have at least two vertices that form the line. These vertices
-  // cannot be a single point as that would mean that we cannot calculate unit vector and then normal for the
-  // offset. This must be handled before calling `open_line_to()`.
-  //
-  // NOTE: Path cannot be open when calling this function.
-  BL_INLINE_IF_NOT_DEBUG BLResult open_line_to(const BLPoint& p1, const BLPoint& n1) noexcept {
-    BL_ASSERT(!is_open());
-    BLPoint w = n1 * d();
-
-    a_out().move_to(_p0 + w);
-    b_out().move_to(_p0 - w);
-
-    _p0 = p1;
-    _n0 = n1;
-    _nInitial = n1;
-
-    a_out().line_to(_p0 + w);
-    b_out().line_to(_p0 - w);
-
-    _flags |= kFlagIsOpen;
-    return BL_SUCCESS;
-  }
-
-  // Joins line-to segment described by `p1` point and `n1` normal.
-  BL_INLINE_IF_NOT_DEBUG BLResult join_line_to(const BLPoint& p1, const BLPoint& n1) noexcept {
-    if (_n0 == n1) {
-      // Collinear case - patch the previous point(s) if they connect lines.
-      a_out().back(a_out().cmd[-2].value <= BL_PATH_CMD_ON);
-      b_out().back(b_out().cmd[-2].value <= BL_PATH_CMD_ON);
-
-      BLPoint w1 = n1 * d();
-      a_out().line_to(p1 + w1);
-      b_out().line_to(p1 - w1);
-    }
-    else {
-      Side side = side_from_normals(_n0, n1);
-      BLPoint m = _n0 + n1;
-      BLPoint k = m * d2(side) / Geometry::magnitude_squared(m);
-      BLPoint w1 = n1 * d(side);
-
-      size_t miter_flag = 0;
-
-      if (side == Side::kA) {
-        PathAppender& outer = a_out();
-        outer_join(outer, n1, w1, k, d(side), d2(side), miter_flag);
-        outer.back(miter_flag);
-        outer.line_to(p1 + w1);
-
-        PathAppender& inner = b_out();
-        inner_join_line_to(inner, _p0 - w1, p1 - w1, _p0 - k);
-        inner.line_to(p1 - w1);
-      }
-      else {
-        PathAppender& outer = b_out();
-        outer_join(outer, n1, w1, k, d(side), d2(side), miter_flag);
-        outer.back(miter_flag);
-        outer.line_to(p1 + w1);
-
-        PathAppender& inner = a_out();
-        inner_join_line_to(inner, _p0 - w1, p1 - w1, _p0 - k);
-        inner.line_to(p1 - w1);
-      }
-    }
-
-    _p0 = p1;
-    _n0 = n1;
-    return BL_SUCCESS;
-  }
-
-  // Opens a new figure at the current point `_p0`. The first vertex (MOVE) is calculated by offsetting `_p0`
-  // by the given unit normal `n0`.
-  //
-  // NOTE: Path cannot be open when calling this function.
-  BL_INLINE_IF_NOT_DEBUG BLResult open_curve(const BLPoint& n0) noexcept {
-    BL_ASSERT(!is_open());
-    BLPoint w = n0 * d();
-
-    a_out().move_to(_p0 + w);
-    b_out().move_to(_p0 - w);
-
-    _n0 = n0;
-    _nInitial = n0;
-
-    _flags |= kFlagIsOpen;
-    return BL_SUCCESS;
-  }
-
-  // Joins curve-to segment.
-  BL_INLINE_IF_NOT_DEBUG BLResult join_curve(const BLPoint& n1) noexcept {
-    // Collinear case - do nothing.
-    if (_n0 == n1)
-      return BL_SUCCESS;
-
-    Side side = side_from_normals(_n0, n1);
-    BLPoint m = _n0 + n1;
-    BLPoint k = m * d2(side) / Geometry::magnitude_squared(m);
-    BLPoint w1 = n1 * d(side);
-    size_t dummy_miter_flag;
-
-    outer_join(outer_appender(side), n1, w1, k, d(side), d2(side), dummy_miter_flag);
-    inner_join_curve_to(inner_appender(side), _p0 - w1);
-
-    _n0 = n1;
-    return BL_SUCCESS;
-  }
-
-  BL_INLINE_IF_NOT_DEBUG BLResult join_cusp(const BLPoint& n1) noexcept {
-    Side side = side_from_normals(_n0, n1);
-    BLPoint w1 = n1 * d(side);
-
-    dull_round_join(outer_appender(side), d(side), d2(side), w1);
-    inner_appender(side).line_to(_p0 - w1);
-
-    _n0 = n1;
-    return BL_SUCCESS;
-  }
-
-  BL_INLINE_IF_NOT_DEBUG BLResult join_cusp_and_line_to(const BLPoint& n1, const BLPoint& p1) noexcept {
-    Side side = side_from_normals(_n0, n1);
-    BLPoint w1 = n1 * d(side);
-
-    PathAppender& outer = outer_appender(side);
-    dull_round_join(outer, d(side), d2(side), w1);
-    outer.line_to(p1 + w1);
-
-    PathAppender& inner = inner_appender(side);
-    inner.line_to(_p0 - w1);
-    inner.line_to(p1 - w1);
-
-    _n0 = n1;
-    _p0 = p1;
-    return BL_SUCCESS;
-  }
-
-  BL_INLINE_IF_NOT_DEBUG BLResult smooth_poly_to(const BLPoint* poly, size_t count) noexcept {
-    BL_ASSERT(count >= 2);
-
-    BLPoint p1 = poly[0];
-    BLPoint v1 = p1 - _p0;
-    if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
-      return BL_SUCCESS;
-
-    BLPoint n1 = Geometry::normal(Geometry::unit_vector(v1));
-    if (!is_open())
-      BL_PROPAGATE(open_line_to(p1, n1));
-    else
-      BL_PROPAGATE(join_line_to(p1, n1));
-
-    // We have already ensured vertices for `open_line_to()` and `join_line_to()`,
-    // however, we need more vertices for consecutive joins and line segments.
-    size_t required_capacity = (count - 1) * kStrokeMaxJoinVertices;
-    BL_PROPAGATE(ensure_appenders_capacity(required_capacity, required_capacity));
-
-    for (size_t i = 1; i < count; i++) {
-      p1 = poly[i];
-      v1 = p1 - _p0;
-      if (Geometry::magnitude_squared(v1) < kStrokeLengthEpsilonSq)
-        continue;
-
-      n1 = Geometry::normal(Geometry::unit_vector(v1));
-      BL_PROPAGATE(join_cusp_and_line_to(n1, p1));
-    }
-
-    return BL_SUCCESS;
-  }
-
-  // Joins end point that is only applied to closed figures.
-  BL_INLINE_IF_NOT_DEBUG BLResult join_end_point(const BLPoint& n1) noexcept {
-    if (_n0 == n1) {
-      // Collinear case - patch the previous point(s) if they connect lines.
-      a_out().back(a_out().cmd[-2].value <= BL_PATH_CMD_ON);
-      b_out().back(b_out().cmd[-2].value <= BL_PATH_CMD_ON);
-      return BL_SUCCESS;
-    }
-
-    Side side = side_from_normals(_n0, n1);
-    BLPoint m = _n0 + n1;
-    BLPoint w1 = n1 * d(side);
-    BLPoint k = m * d2(side) / Geometry::magnitude_squared(m);
-
-    size_t miter_flag = 0;
-
-    BLPathPrivateImpl* outer_impl = get_impl(outer_path(side));
-    size_t outer_start = side_data(side).figure_offset;
-
-    PathAppender& outer = outer_appender(side);
-    outer_join(outer, n1, w1, k, d(side), d2(side), miter_flag);
-
-    // Shift the start point to be at the miter intersection and remove the
-    // Line from the intersection to the start of the path if miter was applied.
-    if (miter_flag) {
-      if (outer_impl->command_data[outer_start + 1] == BL_PATH_CMD_ON) {
-        outer.back();
-        outer_impl->vertex_data[outer_start] = outer.vtx[-1];
-        outer.back(outer.cmd[-2].value <= BL_PATH_CMD_ON);
-      }
-    }
-
-    BLPathPrivateImpl* inner_impl = get_impl(inner_path(side));
-    size_t inner_start = side_data(opposite_side(side)).figure_offset;
-
-    if (inner_impl->command_data[inner_start + 1] <= BL_PATH_CMD_ON) {
-      inner_join_end_point(inner_appender(side), inner_impl->vertex_data[inner_start], inner_impl->vertex_data[inner_start + 1], _p0 - k);
-    }
-
-    return BL_SUCCESS;
-  }
-
-  BL_INLINE_IF_NOT_DEBUG void inner_join_curve_to(PathAppender& out, const BLPoint& p1) noexcept {
-    out.line_to(_p0);
-    out.line_to(p1);
-  }
-
-  BL_INLINE_IF_NOT_DEBUG void inner_join_line_to(PathAppender& out, const BLPoint& lineP0, const BLPoint& lineP1, const BLPoint& inner_pt) noexcept {
-    if (out.cmd[-2].value <= BL_PATH_CMD_ON && test_inner_join_intersecion(out.vtx[-2], out.vtx[-1], lineP0, lineP1, inner_pt)) {
-      out.vtx[-1] = inner_pt;
-    }
-    else {
-      out.line_to(_p0);
-      out.line_to(lineP0);
-    }
-  }
-
-  BL_INLINE_IF_NOT_DEBUG void inner_join_end_point(PathAppender& out, BLPoint& lineP0, const BLPoint& lineP1, const BLPoint& inner_pt) noexcept {
-    if (out.cmd[-2].value <= BL_PATH_CMD_ON && test_inner_join_intersecion(out.vtx[-2], out.vtx[-1], lineP0, lineP1, inner_pt)) {
-      lineP0 = inner_pt;
-      out.back(1);
-    }
-    else {
-      out.line_to(_p0);
-      out.line_to(lineP0);
-    }
-  }
-
-  // Calculates outer join to `pb`.
-  BL_INLINE_IF_NOT_DEBUG BLResult outer_join(PathAppender& appender, const BLPoint& n1, const BLPoint& w1, const BLPoint& k, double d, double d2, size_t& miter_flag) noexcept {
-    BLPoint pb = _p0 + w1;
-
-    if (Geometry::magnitude_squared(k) <= _miter_limit_sq) {
-      // Miter condition is met.
-      appender.back(appender.cmd[-2].value <= BL_PATH_CMD_ON);
-      appender.line_to(_p0 + k);
-      appender.line_to(pb);
-
-      miter_flag = 1;
-      return BL_SUCCESS;
-    }
-
-    if (_join_type == BL_STROKE_JOIN_MITER_CLIP) {
-      double b2 = bl_abs(Geometry::cross(k, _n0));
-
-      // Avoid degenerate cases and NaN.
-      if (b2 > 0)
-        b2 = b2 * _miter_limit / Geometry::magnitude(k);
-      else
-        b2 = _miter_limit;
-
-      appender.back(appender.cmd[-2].value <= BL_PATH_CMD_ON);
-      appender.line_to(_p0 + d * _n0 - b2 * Geometry::normal(_n0));
-      appender.line_to(_p0 + d *  n1 + b2 * Geometry::normal(n1));
-
-      miter_flag = 1;
-      appender.line_to(pb);
-      return BL_SUCCESS;
-    }
-
-    if (_join_type == BL_STROKE_JOIN_ROUND) {
-      BLPoint pa = appender.vtx[-1];
-      if (Geometry::dot(_p0 - pa, _p0 - pb) < 0.0) {
-        // Dull angle.
-        BLPoint n2 = Geometry::normal(Geometry::unit_vector(pb - pa));
-        BLPoint m = _n0 + n2;
-        BLPoint k0 = d2 * m / Geometry::magnitude_squared(m);
-        BLPoint q = d * n2;
-
-        BLPoint pc1 = _p0 + k0;
-        BLPoint pp1 = _p0 + q;
-        BLPoint pc2 = Math::lerp(pc1, pp1, 2.0);
-
-        angle_arc_to(appender, _p0, pa, pp1, pc1);
-        angle_arc_to(appender, _p0, pp1, pb, pc2);
-      }
-      else {
-        // Acute angle.
-        angle_arc_to(appender, _p0, pa, pb, _p0 + k);
-      }
-      return BL_SUCCESS;
-    }
-
-    // Bevel or unknown `_join_type`.
-    appender.line_to(pb);
-    return BL_SUCCESS;
-  }
-
-  // Calculates round join to `pb` (dull angle), only used by offsetting cusps.
-  BL_INLINE_IF_NOT_DEBUG BLResult dull_round_join(PathAppender& out, double d, double d2, const BLPoint& w1) noexcept {
-    BLPoint pa = out.vtx[-1];
-    BLPoint pb = _p0 + w1;
-    BLPoint n2 = Geometry::normal(Geometry::unit_vector(pb - pa));
-
-    if (!Math::is_finite(n2.x))
-      return BL_SUCCESS;
-
-    BLPoint m = _n0 + n2;
-    BLPoint k = m * d2 / Geometry::magnitude_squared(m);
-    BLPoint q = n2 * d;
-
-    BLPoint pc1 = _p0 + k;
-    BLPoint pp1 = _p0 + q;
-    BLPoint pc2 = Math::lerp(pc1, pp1, 2.0);
-
-    angle_arc_to(out, _p0, pa, pp1, pc1);
-    angle_arc_to(out, _p0, pp1, pb, pc2);
-    return BL_SUCCESS;
-  }
-
-  BL_INLINE_IF_NOT_DEBUG BLResult offset_quad(const BLPoint bez[3]) noexcept {
-    double ts[3];
-    size_t tn = Geometry::quad_offset_cusp_ts(Geometry::quad_ref(bez), d(), ts);
-    ts[tn++] = 1.0;
-
-    Geometry::QuadCurveTsIter iter(Geometry::quad_ref(bez), Span<double>(ts, tn));
-    double m = _approx.offset_parameter;
-
-    do {
-      for (;;) {
-        BL_PROPAGATE(ensure_appenders_capacity(2, 2));
-
-        double t = Geometry::quad_parameter_at_angle(iter.part, m);
-        if (!(t > kOffsetQuadEpsilonT && t < 1.0 - kOffsetQuadEpsilonT))
-          t = 1.0;
-
-        BLPoint part[3];
-        Geometry::split(Geometry::quad_ref(iter.part), Geometry::quad_out(part), Geometry::quad_out(iter.part), t);
-        offset_quad_simple(part[0], part[1], part[2]);
-
-        if (t == 1.0)
-          break;
-      }
-    } while (iter.next());
-
-    return BL_SUCCESS;
-  }
-
-  BL_INLINE_IF_NOT_DEBUG void offset_quad_simple(const BLPoint& p0, const BLPoint& p1, const BLPoint& p2) noexcept {
-    if (p0 == p2)
-      return;
-
-    BLPoint v0 = p1 - p0;
-    BLPoint v1 = p2 - p1;
-
-    BLPoint m0 = Geometry::normal(Geometry::unit_vector(p0 != p1 ? v0 : v1));
-    BLPoint m2 = Geometry::normal(Geometry::unit_vector(p1 != p2 ? v1 : v0));
-
-    _p0 = p2;
-    _n0 = m2;
-
-    BLPoint m = m0 + m2;
-    BLPoint k1 = m * d2() / Geometry::magnitude_squared(m);
-    BLPoint k2 = m2 * d();
-
-    a_out().quad_to(p1 + k1, p2 + k2);
-    b_out().quad_to(p1 - k1, p2 - k2);
-  }
-
-  static BL_INLINE BLPoint evaluate_projective_conic(const BLPoint proj[6], double t) noexcept {
-    BLPoint q01 = Math::lerp(proj[0], proj[2], t);
-    BLPoint w01 = Math::lerp(proj[1], proj[3], t);
-    BLPoint q12 = Math::lerp(proj[2], proj[4], t);
-    BLPoint w12 = Math::lerp(proj[3], proj[5], t);
-    BLPoint q012 = Math::lerp(q01, q12, t);
-    BLPoint w012 = Math::lerp(w01, w12, t);
-
-    return q012 / w012.x;
-  }
-
-  static BL_INLINE void approximate_projective_conic_with_quad(const BLPoint proj[6], BLPoint quad[3]) noexcept {
-    BLPoint p0 = proj[0] / proj[1].x;
-    BLPoint p2 = proj[4] / proj[5].x;
-
-    BLPoint v0 = proj[2] * proj[1].x - proj[0] * proj[3].x;
-    BLPoint v1 = proj[4] * proj[3].x - proj[2] * proj[5].x;
-    double v0m2 = Geometry::magnitude_squared(v0);
-    double v1m2 = Geometry::magnitude_squared(v1);
-    double cross = Geometry::cross(v0, v1);
-
-    quad[0] = p0;
-    quad[2] = p2;
-
-    if (v0m2 > kStrokeLengthEpsilonSq && v1m2 > kStrokeLengthEpsilonSq && Math::square(cross) > kStrokeCollinearityEpsilonSq * v0m2 * v1m2) {
-      quad[1] = Geometry::line_vector_intersection(p0, v0, p2, -v1);
-    }
-    else {
-      BLPoint pm = evaluate_projective_conic(proj, 0.5);
-      quad[1] = pm * 2.0 - (p0 + p2) * 0.5;
-    }
-  }
-
-  template<typename Callback>
-  BL_INLINE_IF_NOT_DEBUG BLResult approximate_conic_with_quads(const BLPoint conic[4], const Callback& callback) noexcept {
-    struct ConicApproximationPart {
-      BLPoint proj[6];
-      uint32_t depth;
-    };
-
-    BLPoint spline[30];
-    BLPoint projective[6];
-    BLPoint* spline_ptr = spline;
-    BLPoint* spline_end = Geometry::split_conic_to_spline<Geometry::QuadSplitOptions::kExtremaXY>(conic, spline_ptr);
-
-    if (spline_end == spline_ptr) {
-      Geometry::get_conic_projective_points(conic, projective);
-      spline_ptr = projective;
-      spline_end = projective + 6;
-    }
-
-    double tolerance_sq = Math::square(4.0 * _approx.simplify_tolerance);
-    ConicApproximationPart stack[kApproxCurveMaxDepth + 1];
-
-    do {
-      size_t stack_size = 1;
-      for (size_t i = 0; i < 6; i++)
-        stack[0].proj[i] = spline_ptr[i];
-      stack[0].depth = 0;
-
-      while (stack_size) {
-        ConicApproximationPart part = stack[--stack_size];
-        BLPoint quad[3];
-
-        approximate_projective_conic_with_quad(part.proj, quad);
-
-        BLPoint pm0 = evaluate_projective_conic(part.proj, 0.5);
-        BLPoint pm1 = Geometry::evaluate_precise(Geometry::quad_ref(quad), 0.5);
-
-        if (part.depth < kApproxCurveMaxDepth && Geometry::magnitude_squared(pm0 - pm1) > tolerance_sq) {
-          BLPoint left[6];
-          BLPoint right[6];
-
-          Geometry::split_projective_conic(part.proj, left, right, 0.5);
-
-          for (size_t i = 0; i < 6; i++) {
-            stack[stack_size].proj[i] = right[i];
-            stack[stack_size + 1].proj[i] = left[i];
-          }
-          stack[stack_size].depth = part.depth + 1;
-          stack[stack_size + 1].depth = part.depth + 1;
-          stack_size += 2;
+          BL_PROPAGATE(conic_to(p1, p2, w));
           continue;
         }
 
-        BL_PROPAGATE(callback(quad));
-      }
-    } while ((spline_ptr += 6) != spline_end);
+        if (cmd == BL_PATH_CMD_CUBIC) {
+          if (_iter.remaining_forward() < 3)
+            return bl_make_error(BL_ERROR_INVALID_GEOMETRY);
 
-    return BL_SUCCESS;
-  }
+          BLPoint p1 = _iter.vtx[0];
+          BLPoint p2 = _iter.vtx[1];
+          BLPoint p3 = _iter.vtx[2];
+          _iter += 3;
+          BL_PROPAGATE(cubic_to(p1, p2, p3));
+          continue;
+        }
 
-  struct ConicApproximateSink {
-    PathStroker& _stroker;
+        if (cmd == BL_PATH_CMD_CLOSE) {
+          _iter++;
+          if (has_non_butt_caps(_options) && (has_only_move_to() || is_current_contour_empty())) {
+            BL_PROPAGATE(line_to(move_to_pt()));
+          }
+          else {
+            contour_closed = true;
+          }
+          break;
+        }
 
-    BL_INLINE ConicApproximateSink(PathStroker& stroker) noexcept
-      : _stroker(stroker) {}
-
-    BL_INLINE BLResult operator()(const BLPoint quad[3]) const noexcept {
-      return _stroker.offset_quad(quad);
-    }
-  };
-
-  BL_INLINE_IF_NOT_DEBUG BLResult offset_conic(const BLPoint conic[4]) noexcept {
-    ConicApproximateSink sink(*this);
-    return approximate_conic_with_quads(conic, sink);
-  }
-
-  struct CubicApproximateSink {
-    PathStroker& _stroker;
-
-    BL_INLINE CubicApproximateSink(PathStroker& stroker) noexcept
-      : _stroker(stroker) {}
-
-    BL_INLINE BLResult operator()(BLPoint quad[3]) const noexcept {
-      return _stroker.offset_quad(quad);
-    }
-  };
-
-  BL_INLINE_IF_NOT_DEBUG BLResult offset_cubic(const BLPoint bez[4]) noexcept {
-    CubicApproximateSink sink(*this);
-    return Geometry::approximate_cubic_with_quads(Geometry::cubic_ref(bez), _approx.simplify_tolerance, kApproxCurveMaxDepth, sink);
-  }
-
-  BL_INLINE_IF_NOT_DEBUG BLResult add_cap(PathAppender& out, BLPoint pivot, BLPoint p1, uint32_t cap_type) noexcept {
-    BLPoint p0 = out.vtx[-1];
-    BLPoint q = Geometry::normal(p1 - p0) * 0.5;
-
-    switch (cap_type) {
-      case BL_STROKE_CAP_BUTT:
-      default: {
-        out.line_to(p1);
         break;
       }
 
-      case BL_STROKE_CAP_SQUARE: {
-        out.line_to(p0 + q);
-        out.line_to(p1 + q);
-        out.line_to(p1);
-        break;
-      }
+      BL_PROPAGATE(finish_contour(contour_closed));
 
-      case BL_STROKE_CAP_ROUND: {
-        out.arc_quadrant_to(p0 + q, pivot + q);
-        out.arc_quadrant_to(p1 + q, p1);
-        break;
-      }
+      _a_out.done(_a_path);
+      _b_out.done(_b_path);
 
-      case BL_STROKE_CAP_ROUND_REV: {
-        out.line_to(p0 + q);
-        out.arc_quadrant_to(p0, pivot);
-        out.arc_quadrant_to(p1, p1 + q);
-        out.line_to(p1);
-        break;
-      }
+      if (!_cusp_path.is_empty())
+        BL_PROPAGATE(_a_path->add_path(_cusp_path));
 
-      case BL_STROKE_CAP_TRIANGLE: {
-        out.line_to(pivot + q);
-        out.line_to(p1);
-        break;
-      }
-
-      case BL_STROKE_CAP_TRIANGLE_REV: {
-        out.line_to(p0 + q);
-        out.line_to(pivot);
-        out.line_to(p1 + q);
-        out.line_to(p1);
-        break;
-      }
+      size_t figure_end_idx = figure_start_idx + size_t(_iter.cmd - figure_start_cmd);
+      BL_PROPAGATE(sink(_a_path, _b_path, _c_path, figure_start_idx, figure_end_idx, user_data));
+      figure_start_idx = figure_end_idx;
     }
 
     return BL_SUCCESS;

--- a/blend2d/geometry/bezier_p.h
+++ b/blend2d/geometry/bezier_p.h
@@ -940,7 +940,7 @@ static BL_INLINE void approximate_cubic_with_two_quads(CubicRef curve, BLPoint q
 }
 
 template<typename Callback>
-static BL_INLINE BLResult approximate_cubic_with_quads(CubicRef curve, double simplify_tolerance, const Callback& callback) noexcept {
+static BL_INLINE BLResult approximate_cubic_with_quads(CubicRef curve, double simplify_tolerance, uint32_t max_split_steps, const Callback& callback) noexcept {
   // Tolerance consists of a prefactor (27/4 * 2^3) combined with `simplify_tolerance`.
   double tolerance_sq = Math::square(54.0 * simplify_tolerance);
 
@@ -953,12 +953,19 @@ static BL_INLINE BLResult approximate_cubic_with_quads(CubicRef curve, double si
   cubic[5] = curve.vtx[2];
   cubic[6] = curve.vtx[3];
 
+  uint32_t split_steps = 0;
+
   for (;;) {
     BLPoint quads[5];
-    t = bl_min(1.0, t);
-
-    if (t >= 0.999)
+    if (split_steps >= max_split_steps) {
       t = 1.0;
+    }
+    else {
+      t = bl_min(1.0, t);
+
+      if (t >= 0.999)
+        t = 1.0;
+    }
 
     // Split the cubic:
     //   - cubic[0:3] contains the part before `t`.
@@ -971,6 +978,8 @@ static BL_INLINE BLResult approximate_cubic_with_quads(CubicRef curve, double si
 
     if (t >= 1.0)
       return BL_SUCCESS;
+
+    split_steps++;
 
     // Recalculate the parameter.
     double oldT = t;
@@ -988,41 +997,98 @@ static BL_INLINE BLResult approximate_cubic_with_quads(CubicRef curve, double si
 //!
 //! \{
 
+static BL_INLINE void get_conic_projective_points(const BLPoint p[4], BLPoint out[6]) noexcept {
+  BLPoint p0 = p[0];
+  BLPoint p1 = p[1];
+  double w = p[2].x;
+  BLPoint p2 = p[3];
+
+  out[0] = p0;
+  out[1] = BLPoint(1.0, Math::nan<double>());
+  out[2] = p1 * w;
+  out[3] = BLPoint(w, Math::nan<double>());
+  out[4] = p2;
+  out[5] = BLPoint(1.0, Math::nan<double>());
+}
+
+static BL_INLINE void split_projective_conic(const BLPoint p[6], BLPoint left[6], BLPoint right[6], double t) noexcept {
+  BLPoint q01 = lerp(p[0], p[2], t);
+  BLPoint w01 = lerp(p[1], p[3], t);
+  BLPoint q12 = lerp(p[2], p[4], t);
+  BLPoint w12 = lerp(p[3], p[5], t);
+  BLPoint q012 = lerp(q01, q12, t);
+  BLPoint w012 = lerp(w01, w12, t);
+
+  left[0] = p[0];
+  left[1] = p[1];
+  left[2] = q01;
+  left[3] = w01;
+  left[4] = q012;
+  left[5] = w012;
+
+  right[0] = q012;
+  right[1] = w012;
+  right[2] = q12;
+  right[3] = w12;
+  right[4] = p[4];
+  right[5] = p[5];
+}
+
+static BL_INLINE void get_conic_derivative_coefficients(const BLPoint p[4], BLPoint& a, BLPoint& b, BLPoint& c) noexcept;
+
 template<QuadSplitOptions Options>
-static BL_INLINE BLPoint* split_conic_to_spline(const BLPoint p[3], BLPoint* out) noexcept {
+static BL_INLINE BLPoint* split_conic_to_spline(const BLPoint p[4], BLPoint* out) noexcept {
   static_assert(uint32_t(Options) != 0, "Split options cannot be empty");
 
-  // 2 extremas and 1 terminating `1.0` value.
-  constexpr uint32_t kMaxTCount = 3;
+  // Each axis can contribute up to two extrema.
+  constexpr uint32_t kMaxTCount = 4;
   FixedArray<double, kMaxTCount> ts;
 
-  QuadCoefficients qc = coefficients_of(quad_ref(p));
+  auto append_t = [&](double t) noexcept {
+    if (!(t > 0.0 && t < 1.0))
+      return;
 
-  // Find extremas.
-  if ((Options & QuadSplitOptions::kExtremaXY) == QuadSplitOptions::kExtremaXY) {
-    BLPoint extrema_ts = (p[0] - p[1]) / (p[0] - p[1] * 2.0 + p[2]);
-    double extremaT0 = bl_min(extrema_ts.x, extrema_ts.y);
-    double extremaT1 = bl_max(extrema_ts.x, extrema_ts.y);
+    size_t i = 0;
+    while (i != ts.size() && ts[i] < t)
+      i++;
 
-    ts.append_if(extremaT0, (extremaT0 > 0.0) & (extremaT0 < 1.0));
-    ts.append_if(extremaT1, (extremaT1 > bl_max(extremaT0, 0.0)) & (extremaT1 < 1.0));
+    if (i != ts.size() && bl_abs(ts[i] - t) <= Math::epsilon<double>())
+      return;
+
+    ts.append(0.0);
+    for (size_t j = ts.size() - 1; j != i; j--)
+      ts[j] = ts[j - 1];
+    ts[i] = t;
+  };
+
+  BLPoint a, b, c;
+  get_conic_derivative_coefficients(p, a, b, c);
+
+  auto append_roots = [&](double qa, double qb, double qc) noexcept {
+    if (Math::is_near_zero(qa)) {
+      if (!Math::is_near_zero(qb))
+        append_t(-qc / qb);
+      return;
+    }
+
+    double roots[2];
+    size_t n = Math::quad_roots(roots, qa, qb, qc, Math::kAfter0, Math::kBefore1);
+    for (size_t i = 0; i < n; i++)
+      append_t(roots[i]);
+  };
+
+  if ((Options & QuadSplitOptions::kExtremaXY) == QuadSplitOptions::kExtremaXY || bl_test_flag(Options, QuadSplitOptions::kExtremaX)) {
+    append_roots(a.x, b.x, c.x);
   }
-  else if (bl_test_flag(Options, QuadSplitOptions::kExtremaX)) {
-    double extrema_tx = (p[0].x - p[1].x) / (p[0].x - p[1].x * 2.0 + p[2].x);
-    ts.append_if(extrema_tx, (extrema_tx > 0.0) & (extrema_tx < 1.0));
-  }
-  else if (bl_test_flag(Options, QuadSplitOptions::kExtremaY)) {
-    double extrema_ty = (p[0].y - p[1].y) / (p[0].y - p[1].y * 2.0 + p[2].y);
-    ts.append_if(extrema_ty, (extrema_ty > 0.0) & (extrema_ty < 1.0));
+
+  if ((Options & QuadSplitOptions::kExtremaXY) == QuadSplitOptions::kExtremaXY || bl_test_flag(Options, QuadSplitOptions::kExtremaY)) {
+    append_roots(a.y, b.y, c.y);
   }
 
   // Split the curve into a spline, if necessary.
   if (!ts.is_empty()) {
-    // The last T we want is at 1.0.
-    ts.append(1.0);
-
-    out[0] = p[0];
-    BLPoint last = p[2];
+    BLPoint current[6];
+    get_conic_projective_points(p, current);
 
     size_t i = 0;
     double tCut = 0.0;
@@ -1032,22 +1098,22 @@ static BL_INLINE BLPoint* split_conic_to_spline(const BLPoint p[3], BLPoint* out
       BL_ASSERT(tVal >  0.0);
       BL_ASSERT(tVal <= 1.0);
 
-      double dt = (tVal - tCut) * 0.5;
+      double dt = (tVal - tCut) / (1.0 - tCut);
+      BLPoint next[6];
+      split_projective_conic(current, out, next, dt);
 
-      // Derivative: 2a*t + b.
-      BLPoint cp = (qc.a * (tVal * 2.0) + qc.b) * dt;
-      BLPoint tp = (qc.a * tVal + qc.b) * tVal + qc.c;
+      for (size_t j = 0; j < 6; j++)
+        current[j] = next[j];
 
-      // The last point must be exact.
-      if (++i == ts.size())
-        tp = last;
-
-      out[1].reset(tp - cp);
-      out[2].reset(tp);
-      out += 2;
+      out += 6;
+      i++;
 
       tCut = tVal;
-    } while (i != ts.size());
+    } while (i < ts.size());
+
+    for (size_t j = 0; j < 6; j++)
+      out[j] = current[j];
+    out += 6;
   }
 
   return out;
@@ -1069,35 +1135,25 @@ static BL_INLINE void get_conic_derivative_coefficients(const BLPoint p[4], BLPo
   c = 2 * w * v1;
 }
 
-static BL_INLINE void get_projective_points(const BLPoint p[4], BLPoint out[6]) noexcept {
-  BLPoint p0 = p[0];
-  BLPoint p1 = p[1];
-  double w = p[2].x;
-  BLPoint p2 = p[3];
-
-  out[0] = BLPoint(p0.x, 1);
-  out[1] = BLPoint(w * p1.x,  w);
-  out[2] = BLPoint(p2.x,  1);
-
-  out[3] = BLPoint(p0.y, 1);
-  out[4] = BLPoint(w * p1.y, w);
-  out[5] = BLPoint(p2.y, 1);
-}
-
 static BL_INLINE BLPoint eval_conic_precise(const BLPoint p[4], const BLPoint& t) noexcept {
   BLPoint pp[6];
-  get_projective_points(p, pp);
+  get_conic_projective_points(p, pp);
 
-  BLPoint ppx01(lerp(pp[0], pp[1], t.x));
-  BLPoint ppy01(lerp(pp[3], pp[4], t.y));
+  BLPoint q01x(lerp(pp[0], pp[2], t.x));
+  BLPoint w01x(lerp(pp[1], pp[3], t.x));
+  BLPoint q12x(lerp(pp[2], pp[4], t.x));
+  BLPoint w12x(lerp(pp[3], pp[5], t.x));
+  BLPoint q012x(lerp(q01x, q12x, t.x));
+  BLPoint w012x(lerp(w01x, w12x, t.x));
 
-  BLPoint ppx12(lerp(pp[1], pp[2], t.x));
-  BLPoint ppy12(lerp(pp[4], pp[5], t.y));
+  BLPoint q01y(lerp(pp[0], pp[2], t.y));
+  BLPoint w01y(lerp(pp[1], pp[3], t.y));
+  BLPoint q12y(lerp(pp[2], pp[4], t.y));
+  BLPoint w12y(lerp(pp[3], pp[5], t.y));
+  BLPoint q012y(lerp(q01y, q12y, t.y));
+  BLPoint w012y(lerp(w01y, w12y, t.y));
 
-  BLPoint ppx012(lerp(ppx01, ppx12, t.x));
-  BLPoint ppy012(lerp(ppy01, ppy12, t.y));
-
-  return BLPoint(ppx012.x / ppx012.y, ppy012.x / ppy012.y);
+  return BLPoint(q012x.x / w012x.x, q012y.y / w012y.x);
 }
 
 

--- a/blend2d/geometry/bezier_test.cpp
+++ b/blend2d/geometry/bezier_test.cpp
@@ -13,8 +13,54 @@
 
 namespace bl::Tests {
 
-UNIT(geometry_bezier, BL_TEST_GROUP_GEOMETRY_UTILITIES) {
+struct CountingQuadSink {
+  mutable size_t count;
 
+  BL_INLINE BLResult operator()(BLPoint[3]) const noexcept {
+    count++;
+    return BL_SUCCESS;
+  }
+};
+
+UNIT(geometry_bezier, BL_TEST_GROUP_GEOMETRY_UTILITIES) {
+  {
+    constexpr double w = 0.5;
+    BLPoint conic[4] {
+      BLPoint(0.0, 0.0),
+      BLPoint(1.0, 3.0),
+      BLPoint(w, Math::nan<double>()),
+      BLPoint(2.0, 0.0)
+    };
+
+    BLPoint spline[30];
+    BLPoint* end = Geometry::split_conic_to_spline<Geometry::QuadSplitOptions::kExtremaY>(conic, spline);
+
+    EXPECT_EQ(size_t(end - spline), size_t(12));
+    EXPECT_EQ(spline[0], BLPoint(0.0, 0.0));
+    EXPECT_EQ(spline[1].x, 1.0);
+    EXPECT_EQ(spline[6], spline[4]);
+    EXPECT_EQ(spline[7], spline[5]);
+    EXPECT_EQ(spline[10], BLPoint(2.0, 0.0));
+    EXPECT_EQ(spline[11].x, 1.0);
+    EXPECT_GT(spline[4].y / spline[5].x, 0.0);
+  }
+
+  {
+    BLPoint cubic[4] {
+      BLPoint(0.0, 0.0),
+      BLPoint(0.0, 100.0),
+      BLPoint(100.0, 100.0),
+      BLPoint(100.0, 0.0)
+    };
+
+    CountingQuadSink sink0 { 0 };
+    EXPECT_SUCCESS(Geometry::approximate_cubic_with_quads(Geometry::cubic_ref(cubic), 1e-12, 0, sink0));
+    EXPECT_EQ(sink0.count, size_t(2));
+
+    CountingQuadSink sink1 { 0 };
+    EXPECT_SUCCESS(Geometry::approximate_cubic_with_quads(Geometry::cubic_ref(cubic), 1e-12, 1, sink1));
+    EXPECT_EQ(sink1.count, size_t(4));
+  }
 }
 
 } // {bl::Tests}

--- a/blend2d/raster/edgebuilder_p.h
+++ b/blend2d/raster/edgebuilder_p.h
@@ -157,8 +157,8 @@ public:
   BL_INLINE void next_cubic_to(BLPoint&, BLPoint&, BLPoint&) noexcept {}
   BL_INLINE bool maybe_next_cubic_to(BLPoint&, BLPoint&, BLPoint&) noexcept { return false; }
 
-  BL_INLINE void next_conic_to(BLPoint&, BLPoint&) noexcept {}
-  BL_INLINE bool maybe_next_conic_to(BLPoint&, BLPoint&) noexcept { return false; }
+  BL_INLINE void next_conic_to(BLPoint&, BLPoint&, double&) noexcept {}
+  BL_INLINE bool maybe_next_conic_to(BLPoint&, BLPoint&, double&) noexcept { return false; }
 };
 
 template<class Transform = EdgeTransformNone>
@@ -166,6 +166,7 @@ class EdgeSourcePath {
 public:
   Transform _transform;
   const BLPoint* _vtx_ptr;
+  const double* _conic_weight_ptr;
   const uint8_t* _cmd_ptr;
   const uint8_t* _cmd_end;
   const uint8_t* _cmdEndMinus2;
@@ -173,25 +174,27 @@ public:
   BL_INLINE EdgeSourcePath(const Transform& transform) noexcept
     : _transform(transform),
       _vtx_ptr(nullptr),
+      _conic_weight_ptr(nullptr),
       _cmd_ptr(nullptr),
       _cmd_end(nullptr),
       _cmdEndMinus2(nullptr) {}
 
   BL_INLINE EdgeSourcePath(const Transform& transform, const BLPathView& view) noexcept
-    : _transform(transform) { reset(view.vertex_data, view.command_data, view.size); }
+    : _transform(transform) { reset(view.vertex_data, view.command_data, view.conic_weight_data, view.size); }
 
-  BL_INLINE EdgeSourcePath(const Transform& transform, const BLPoint* vtx_data, const uint8_t* cmd_data, size_t count) noexcept
-    : _transform(transform) { reset(vtx_data, cmd_data, count); }
+  BL_INLINE EdgeSourcePath(const Transform& transform, const BLPoint* vtx_data, const uint8_t* cmd_data, const double* conic_weight_data, size_t count) noexcept
+    : _transform(transform) { reset(vtx_data, cmd_data, conic_weight_data, count); }
 
-  BL_INLINE void reset(const BLPoint* vtx_data, const uint8_t* cmd_data, size_t count) noexcept {
+  BL_INLINE void reset(const BLPoint* vtx_data, const uint8_t* cmd_data, const double* conic_weight_data, size_t count) noexcept {
     _vtx_ptr = vtx_data;
+    _conic_weight_ptr = conic_weight_data;
     _cmd_ptr = cmd_data;
     _cmd_end = cmd_data + count;
     _cmdEndMinus2 = _cmd_end - 2;
   }
 
   BL_INLINE void reset(const BLPath& path) noexcept {
-    reset(path.vertex_data(), path.command_data(), path.size());
+    reset(path.vertex_data(), path.command_data(), path.conic_weight_data(), path.size());
   }
 
   BL_INLINE bool begin(BLPoint& initial) noexcept {
@@ -216,7 +219,7 @@ public:
   BL_INLINE bool is_close() const noexcept { return _cmd_ptr != _cmd_end && _cmd_ptr[0] == BL_PATH_CMD_CLOSE; }
   BL_INLINE bool is_line_to() const noexcept { return _cmd_ptr != _cmd_end && _cmd_ptr[0] == BL_PATH_CMD_ON; }
   BL_INLINE bool is_quad_to() const noexcept { return _cmd_ptr <= _cmdEndMinus2 && _cmd_ptr[0] == BL_PATH_CMD_QUAD; }
-  BL_INLINE bool is_conic_to() const noexcept { return _cmd_ptr < _cmdEndMinus2 && _cmd_ptr[0] == BL_PATH_CMD_CONIC; }
+  BL_INLINE bool is_conic_to() const noexcept { return _cmd_ptr <= _cmdEndMinus2 && _cmd_ptr[0] == BL_PATH_CMD_CONIC; }
   BL_INLINE bool is_cubic_to() const noexcept { return _cmd_ptr < _cmdEndMinus2 && _cmd_ptr[0] == BL_PATH_CMD_CUBIC; }
 
   BL_INLINE void next_line_to(BLPoint& pt1) noexcept {
@@ -264,18 +267,20 @@ public:
     return true;
   }
 
-  BL_INLINE void next_conic_to(BLPoint& pt1, BLPoint& pt2) noexcept {
+  BL_INLINE void next_conic_to(BLPoint& pt1, BLPoint& pt2, double& w) noexcept {
     _transform.apply(pt1, _vtx_ptr[0]);
-    _transform.apply(pt2, _vtx_ptr[2]);
+    _transform.apply(pt2, _vtx_ptr[1]);
+    w = _conic_weight_ptr[0];
     _cmd_ptr += 2;
     _vtx_ptr += 2;
+    _conic_weight_ptr++;
   }
 
-  BL_INLINE bool maybe_next_conic_to(BLPoint& pt1, BLPoint& pt2) noexcept {
+  BL_INLINE bool maybe_next_conic_to(BLPoint& pt1, BLPoint& pt2, double& w) noexcept {
     if (!is_conic_to())
       return false;
 
-    next_conic_to(pt1, pt2);
+    next_conic_to(pt1, pt2, w);
     return true;
   }
 };
@@ -288,6 +293,7 @@ class EdgeSourceReversePathFromStrokeSink {
 public:
   Transform _transform;
   const BLPoint* _vtx_ptr;
+  const double* _conic_weight_ptr;
   const uint8_t* _cmd_ptr;
   const uint8_t* _cmd_start;
   bool _must_close;
@@ -295,18 +301,20 @@ public:
   BL_INLINE EdgeSourceReversePathFromStrokeSink(const Transform& transform) noexcept
     : _transform(transform),
       _vtx_ptr(nullptr),
+      _conic_weight_ptr(nullptr),
       _cmd_ptr(nullptr),
       _cmd_start(nullptr),
       _must_close(false) {}
 
   BL_INLINE EdgeSourceReversePathFromStrokeSink(const Transform& transform, const BLPathView& view) noexcept
-    : _transform(transform) { reset(view.vertex_data, view.command_data, view.size); }
+    : _transform(transform) { reset(view.vertex_data, view.command_data, view.conic_weight_data, view.size, view.conic_weight_size); }
 
-  BL_INLINE EdgeSourceReversePathFromStrokeSink(const Transform& transform, const BLPoint* vtx_data, const uint8_t* cmd_data, size_t count) noexcept
-    : _transform(transform) { reset(vtx_data, cmd_data, count); }
+  BL_INLINE EdgeSourceReversePathFromStrokeSink(const Transform& transform, const BLPoint* vtx_data, const uint8_t* cmd_data, const double* conic_weight_data, size_t count, size_t conic_weight_size) noexcept
+    : _transform(transform) { reset(vtx_data, cmd_data, conic_weight_data, count, conic_weight_size); }
 
-  BL_INLINE void reset(const BLPoint* vtx_data, const uint8_t* cmd_data, size_t count) noexcept {
+  BL_INLINE void reset(const BLPoint* vtx_data, const uint8_t* cmd_data, const double* conic_weight_data, size_t count, size_t conic_weight_size) noexcept {
     _vtx_ptr = vtx_data + count;
+    _conic_weight_ptr = conic_weight_data + conic_weight_size;
     _cmd_ptr = cmd_data + count;
     _cmd_start = cmd_data;
     _must_close = count > 0 && _cmd_ptr[-1] == BL_PATH_CMD_CLOSE;
@@ -316,7 +324,7 @@ public:
   }
 
   BL_INLINE void reset(const BLPath& path) noexcept {
-    reset(path.vertex_data(), path.command_data(), path.size());
+    reset(path.vertex_data(), path.command_data(), path.conic_weight_data(), path.size(), path.conic_weight_size());
   }
 
   BL_INLINE bool begin(BLPoint& initial) noexcept {
@@ -389,18 +397,20 @@ public:
     return true;
   }
 
-  BL_INLINE void next_conic_to(BLPoint& pt1, BLPoint& pt2) noexcept {
+  BL_INLINE void next_conic_to(BLPoint& pt1, BLPoint& pt2, double& w) noexcept {
     _cmd_ptr -= 2;
     _vtx_ptr -= 2;
-    _transform.apply(pt1, _vtx_ptr[2]);
+    _conic_weight_ptr--;
+    _transform.apply(pt1, _vtx_ptr[1]);
     _transform.apply(pt2, _vtx_ptr[0]);
+    w = _conic_weight_ptr[0];
   }
 
-  BL_INLINE bool maybe_next_conic_to(BLPoint& pt1, BLPoint& pt2) noexcept {
+  BL_INLINE bool maybe_next_conic_to(BLPoint& pt1, BLPoint& pt2, double& w) noexcept {
     if (!is_conic_to())
       return false;
 
-    next_conic_to(pt1, pt2);
+    next_conic_to(pt1, pt2, w);
     return true;
   }
 };
@@ -422,7 +432,7 @@ typedef EdgeSourceReversePathFromStrokeSink<EdgeTransformAffine> EdgeSourceRever
 //! \name Edge Flattening
 //! \{
 
-//! Base data (mostly stack) used by `FlattenMonoQuad` and `FlattenMonoCubic`.
+//! Base data (mostly stack) used by `FlattenMonoQuad`, `FlattenMonoConic` and `FlattenMonoCubic`.
 class FlattenMonoData {
 public:
   enum : size_t {
@@ -430,7 +440,8 @@ public:
 
     kStackSizeQuad  = kRecursionLimit * 3,
     kStackSizeCubic = kRecursionLimit * 4,
-    kStackSizeTotal = kStackSizeCubic
+    kStackSizeConic = kRecursionLimit * 6,
+    kStackSizeTotal = kStackSizeConic
   };
 
   BLPoint _stack[kStackSizeTotal];
@@ -506,7 +517,7 @@ public:
     step.value = d * d;
     step.limit = _tolerance_sq * len_sq;
 
-    return step.value <= step.limit;
+    return step.value <= step.limit || len_sq <= _tolerance_sq;
   }
 
   BL_INLINE void split(SplitStep& step) const noexcept {
@@ -620,7 +631,7 @@ public:
     step.value = bl_max(d1_sq, d2_sq);
     step.limit = _tolerance_sq * len_sq;
 
-    return step.value <= step.limit;
+    return step.value <= step.limit || len_sq <= _tolerance_sq;
   }
 
   BL_INLINE void split(SplitStep& step) const noexcept {
@@ -662,12 +673,14 @@ public:
   }
 };
 
-//! Helper to flatten a monotonic quad curve.
+//! Helper to flatten a monotonic conic curve.
+//! Special care must be taken as conics use homogeneous coordinates.
 class FlattenMonoConic {
 public:
   FlattenMonoData& _flatten_data;
   double _tolerance_sq;
   BLPoint* _stack_ptr;
+  BLPoint _q0, _w0, _q1, _w1, _q2, _w2;
   BLPoint _p0, _p1, _p2;
 
   struct SplitStep {
@@ -677,8 +690,12 @@ public:
     double value;
     double limit;
 
-    BLPoint p01;
-    BLPoint p12;
+    BLPoint q01;
+    BLPoint w01;
+    BLPoint q12;
+    BLPoint w12;
+    BLPoint q012;
+    BLPoint w012;
     BLPoint p012;
   };
 
@@ -690,22 +707,32 @@ public:
     _stack_ptr = _flatten_data._stack;
 
     if (sign_bit == 0) {
-      _p0 = src[0];
-      _p1 = src[1];
-      _p2 = src[2];
+      _q0 = src[0];
+      _w0 = src[1];
+      _q1 = src[2];
+      _w1 = src[3];
+      _q2 = src[4];
+      _w2 = src[5];
     }
     else {
-      _p0 = src[2];
-      _p1 = src[1];
-      _p2 = src[0];
+      _q0 = src[4];
+      _w0 = src[5];
+      _q1 = src[2];
+      _w1 = src[3];
+      _q2 = src[0];
+      _w2 = src[1];
     }
+
+    _p0 = _q0 / _w0.x;
+    _p1 = _q1 / _w1.x;
+    _p2 = _q2 / _w2.x;
   }
 
   BL_INLINE const BLPoint& first() const noexcept { return _p0; }
   BL_INLINE const BLPoint& last() const noexcept { return _p2; }
 
-  BL_INLINE bool can_pop() const noexcept { return _stack_ptr != _flatten_data._stack; }
-  BL_INLINE bool can_push() const noexcept { return _stack_ptr != _flatten_data._stack + FlattenMonoData::kStackSizeQuad; }
+  BL_INLINE bool can_pop() const noexcept { return _stack_ptr >= _flatten_data._stack + 6; }
+  BL_INLINE bool can_push() const noexcept { return _stack_ptr + 6 <= _flatten_data._stack + FlattenMonoData::kStackSizeConic; }
 
   BL_INLINE bool is_left_to_right() const noexcept { return first().x < last().x; }
 
@@ -715,11 +742,13 @@ public:
   BL_INLINE void bound_left_to_right() noexcept {
     _p1.x = bl_clamp(_p1.x, _p0.x, _p2.x);
     _p1.y = bl_clamp(_p1.y, _p0.y, _p2.y);
+    _q1 = _p1 * _w1.x;
   }
 
   BL_INLINE void bound_right_to_left() noexcept {
     _p1.x = bl_clamp(_p1.x, _p2.x, _p0.x);
     _p1.y = bl_clamp(_p1.y, _p0.y, _p2.y);
+    _q1 = _p1 * _w1.x;
   }
 
   BL_INLINE bool is_flat(SplitStep& step) const noexcept {
@@ -732,38 +761,62 @@ public:
     step.value = d * d;
     step.limit = _tolerance_sq * len_sq;
 
-    return step.value <= step.limit;
+    return step.value <= step.limit || len_sq <= _tolerance_sq;
   }
 
   BL_INLINE void split(SplitStep& step) const noexcept {
-    step.p01 = (_p0 + _p1) * 0.5;
-    step.p12 = (_p1 + _p2) * 0.5;
-    step.p012 = (step.p01 + step.p12) * 0.5;
+    step.q01 = (_q0 + _q1) * 0.5;
+    step.w01.x = (_w0.x + _w1.x) * 0.5;
+    step.w01.y = bl::Math::nan<double>();
+    step.q12 = (_q1 + _q2) * 0.5;
+    step.w12.x = (_w1.x + _w2.x) * 0.5;
+    step.w12.y = bl::Math::nan<double>();
+    step.q012 = (step.q01 + step.q12) * 0.5;
+    step.w012.x = (step.w01.x + step.w12.x) * 0.5;
+    step.w012.y =  bl::Math::nan<double>();
+    step.p012 = step.q012 / step.w012.x;
   }
 
   BL_INLINE void push(const SplitStep& step) noexcept {
     // Must be checked before calling `push()`.
     BL_ASSERT(can_push());
 
-    _stack_ptr[0].reset(step.p012);
-    _stack_ptr[1].reset(step.p12);
-    _stack_ptr[2].reset(_p2);
-    _stack_ptr += 3;
+    _stack_ptr[0].reset(step.q012);
+    _stack_ptr[1].reset(step.w012);
+    _stack_ptr[2].reset(step.q12);
+    _stack_ptr[3].reset(step.w12);
+    _stack_ptr[4].reset(_q2);
+    _stack_ptr[5].reset(_w2);
+    _stack_ptr += 6;
 
-    _p1 = step.p01;
+    _q1 = step.q01;
+    _w1 = step.w01;
+    _p1 = _q1 / _w1.x;
+    _q2 = step.q012;
+    _w2 = step.w012;
     _p2 = step.p012;
   }
 
   BL_INLINE void discard_and_advance(const SplitStep& step) noexcept {
+    _q0 = step.q012;
+    _w0 = step.w012;
     _p0 = step.p012;
-    _p1 = step.p12;
+    _q1 = step.q12;
+    _w1 = step.w12;
+    _p1 = _q1 / _w1.x;
   }
 
   BL_INLINE void pop() noexcept {
-    _stack_ptr -= 3;
-    _p0 = _stack_ptr[0];
-    _p1 = _stack_ptr[1];
-    _p2 = _stack_ptr[2];
+    _stack_ptr -= 6;
+    _q0 = _stack_ptr[0];
+    _w0 = _stack_ptr[1];
+    _q1 = _stack_ptr[2];
+    _w1 = _stack_ptr[3];
+    _q2 = _stack_ptr[4];
+    _w2 = _stack_ptr[5];
+    _p0 = _q0 / _w0.x;
+    _p1 = _q1 / _w1.x;
+    _p2 = _q2 / _w2.x;
   }
 };
 
@@ -1896,16 +1949,20 @@ RestartClipLoop:
 
   template<class Source>
   BL_INLINE_IF_NOT_DEBUG BLResult conic_to(Source& source, State& state) noexcept {
-    // 2 extremas and 1 terminating `1.0` value.
-    constexpr uint32_t kMaxTCount = 2 + 1;
+    // 4 extrema and one terminating segment.
+    constexpr uint32_t kMaxTCount = 4 + 1;
 
-    BLPoint spline[kMaxTCount * 2 + 1];
+    BLPoint spline[kMaxTCount * 6];
+    BLPoint conic[4];
     BLPoint& p0 = state.a;
-    BLPoint& p1 = spline[1];
-    BLPoint& p2 = spline[2];
+    BLPoint& p1 = conic[1];
+    BLPoint& pw = conic[2];
+    BLPoint& p2 = conic[3];
 
     uint32_t& p0_flags = state.a_flags;
-    source.next_conic_to(p1, p2);
+    double w;
+    source.next_conic_to(p1, p2, w);
+    pw.reset(w, Math::nan<double>());
 
     for (;;) {
       uint32_t p1_flags = bl_clip_calc_xy_flags(p1, _clip_box_d);
@@ -1923,7 +1980,8 @@ RestartClipLoop:
             end = !source.is_conic_to();
             if (end) break;
 
-            source.next_conic_to(p1, p2);
+            source.next_conic_to(p1, p2, w);
+            pw.reset(w, Math::nan<double>());
             if (!((p1.y <= _clip_box_d.y0) & (p2.y <= _clip_box_d.y0)))
               break;
           }
@@ -1935,7 +1993,8 @@ RestartClipLoop:
             end = !source.is_conic_to();
             if (end) break;
 
-            source.next_conic_to(p1, p2);
+            source.next_conic_to(p1, p2, w);
+            pw.reset(w, Math::nan<double>());
             if (!((p1.y >= _clip_box_d.y1) & (p2.y >= _clip_box_d.y1)))
               break;
           }
@@ -1950,7 +2009,8 @@ RestartClipLoop:
               end = !source.is_conic_to();
               if (end) break;
 
-              source.next_conic_to(p1, p2);
+              source.next_conic_to(p1, p2, w);
+              pw.reset(w, Math::nan<double>());
               if (!((p1.x <= _clip_box_d.x0) & (p2.x <= _clip_box_d.x0)))
                 break;
             }
@@ -1964,7 +2024,8 @@ RestartClipLoop:
               end = !source.is_conic_to();
               if (end) break;
 
-              source.next_conic_to(p1, p2);
+              source.next_conic_to(p1, p2, w);
+              pw.reset(w, Math::nan<double>());
               if (!((p1.x >= _clip_box_d.x1) & (p2.x >= _clip_box_d.x1)))
                 break;
             }
@@ -1980,44 +2041,47 @@ RestartClipLoop:
         continue;
       }
 
-      spline[0] = p0;
+      conic[0] = p0;
 
+      BLPoint projective[6];
       BLPoint* spline_ptr = spline;
-      BLPoint* spline_end = Geometry::split_conic_to_spline<Geometry::QuadSplitOptions::kExtremaXY>(spline, spline_ptr);
+      BLPoint* spline_end = Geometry::split_conic_to_spline<Geometry::QuadSplitOptions::kExtremaXY>(conic, spline_ptr);
 
-      if (spline_end == spline_ptr)
-        spline_end = spline_ptr + 2;
+      if (spline_end == spline_ptr) {
+        Geometry::get_conic_projective_points(conic, projective);
+        spline_ptr = projective;
+        spline_end = projective + 6;
+      }
 
       Appender appender(*this);
       FlattenMonoConic mono_curve(state.flatten_data, _flatten_tolerance_sq);
 
       uint32_t any_flags = p0_flags | p1_flags | p2_flags;
       if (any_flags) {
-        // One or more quad may need clipping.
         do {
-          uint32_t sign_bit = spline_ptr[0].y > spline_ptr[2].y;
+          uint32_t sign_bit = (spline_ptr[0].y / spline_ptr[1].x) > (spline_ptr[4].y / spline_ptr[5].x);
           BL_PROPAGATE(
             flatten_unsafe_mono_curve<FlattenMonoConic>(mono_curve, appender, spline_ptr, sign_bit)
           );
-        } while ((spline_ptr += 2) != spline_end);
+        } while ((spline_ptr += 6) != spline_end);
 
-        p0 = spline_end[0];
+        p0 = p2;
         p0_flags = p2_flags;
       }
       else {
-        // No clipping - optimized fast-path.
         do {
-          uint32_t sign_bit = spline_ptr[0].y > spline_ptr[2].y;
+          uint32_t sign_bit = (spline_ptr[0].y / spline_ptr[1].x) > (spline_ptr[4].y / spline_ptr[5].x);
           BL_PROPAGATE(
             flatten_safe_mono_curve<FlattenMonoConic>(mono_curve, appender, spline_ptr, sign_bit)
           );
-        } while ((spline_ptr += 2) != spline_end);
+        } while ((spline_ptr += 6) != spline_end);
 
-        p0 = spline_end[0];
+        p0 = p2;
       }
 
-      if (!source.maybe_next_conic_to(p1, p2))
+      if (!source.maybe_next_conic_to(p1, p2, w))
         return BL_SUCCESS;
+      pw.reset(w, Math::nan<double>());
     }
   }
 


### PR DESCRIPTION
I mulled over the design of conic weights in the current code base and I think having a separate data field for conics might be a better decision because current code relies on all the vertices being directly transformable and their order reversable. This will make it slower to construct path views however.

The main points of this PR:
1. Implement adaptive subdivision of conics to line segments in `edgebuilder_p.h` with homogeneous coordinates.
2. Port the stroker from Skia (SkStroker.cpp & SkStrokerPriv.cpp) to fix some deadlocking conditions in the current stroker.
3. Added some tests for the stroker which corresponds to bugs I encountered when porting the stroker.